### PR TITLE
Working abstractions around component

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,54 @@ Edit with [Calcit Editor](https://github.com/Cirru/calcit-editor):
 ce
 ```
 
+### Draft
+
+Phlox use a data structure to represent a component.
+Unlikely normal virual DOM solutions, child components are collectted in `:children` field,
+which means users have to grab and fill them in the trees with extra logics:
+
+```cirru
+{}
+  :type :component
+  :s0 $ {}
+  :args $ [] P1 P2
+  :render $ fn (cursor state)
+    fn (args)
+      {}
+        :children $ {}
+          |a-1 TODO
+          |a-2 TODO
+          |find TODO
+        :render $ fn (dict)
+          g
+            {}
+            GRAB |a-1
+            GRAB |a-2
+            GRAB |find
+  :events $ {}
+    :mouse-down $ fn (event cursor state d!)
+      d! :action DATA
+```
+
+After expansion, children are listed with a map, prepraring for handling events:
+
+```cirru
+{}
+  :type :component
+  :children $ {}
+    |a-1 TODO
+    |a-2 TODO
+    :x TODO
+  :tree $ fn (dict)
+    g
+      {}
+      get dict |a-1
+      get dict |a-2
+      get dict :x
+
+  :events COPY
+```
+
 ### License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -25,24 +25,23 @@ which means users have to grab and fill them in the trees with extra logics:
 ```cirru
 {}
   :type :component
-  :s0 $ {}
+  :name :comp-name
   :args $ [] P1 P2
-  :render $ fn (cursor state)
-    fn (args)
-      {}
-        :children $ {}
-          |a-1 TODO
-          |a-2 TODO
-          |find TODO
-        :render $ fn (dict)
-          g
-            {}
-            GRAB |a-1
-            GRAB |a-2
-            GRAB |find
-  :events $ {}
-    :mouse-down $ fn (event cursor state d!)
-      d! :action DATA
+  :render $ fn (states & args)
+    {}
+      :children $ {}
+        |a-1 TODO
+        |a-2 TODO
+        |find TODO
+      :render $ fn (dict)
+        g
+          {}
+          GRAB |a-1
+          GRAB |a-2
+          GRAB |find
+      :events $ {}
+        :mouse-down $ fn (event d!)
+          d! :action DATA
 ```
 
 After expansion, children are listed with a map, prepraring for handling events:
@@ -54,12 +53,12 @@ After expansion, children are listed with a map, prepraring for handling events:
     |a-1 TODO
     |a-2 TODO
     :x TODO
-  :tree $ fn (dict)
+  :tree
     g
       {}
-      get dict |a-1
-      get dict |a-2
-      get dict :x
+      GOT |a-1
+      GOT |a-2
+      GOT :x
 
   :events COPY
 ```

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -35,7 +35,30 @@
                         |j $ {} (:type :leaf) (:by |u0) (:at 1605607737932) (:text |expand-tree)
                         |v $ {} (:type :leaf) (:by |u0) (:at 1605608929110) (:text |get-shape-tree)
                         |x $ {} (:type :leaf) (:by |u0) (:at 1605672962462) (:text |g)
+                        |y $ {} (:type :leaf) (:by |u0) (:at 1605758614897) (:text |>>)
+                        |yT $ {} (:type :leaf) (:by |u0) (:at 1605758741189) (:text |*tree-state)
+                        |yj $ {} (:type :leaf) (:by |u0) (:at 1605759581300) (:text |handle-tree-event)
+                        |yr $ {} (:type :leaf) (:by |u0) (:at 1605760090794) (:text |defcomp)
         :defs $ {}
+          |*store $ {} (:type :expr) (:by |u0) (:at 1605607758411)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605607760929) (:text |defatom)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605758343415) (:text |*store)
+              |r $ {} (:type :expr) (:by |u0) (:at 1605607758411)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605607763074) (:text |{})
+                  |j $ {} (:type :expr) (:by |u0) (:at 1605758155076)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |u0) (:at 1605758157212)
+                        :data $ {}
+                          |T $ {} (:type :expr) (:by |u0) (:at 1605757785442)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605757787010) (:text |:cursor)
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605757788426)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605757788646) (:text |[])
+                          |D $ {} (:type :leaf) (:by |u0) (:at 1605758157822) (:text |{})
+                      |D $ {} (:type :leaf) (:by |u0) (:at 1605758156609) (:text |:states)
           |main! $ {} (:type :expr) (:by |u0) (:at 1605513219471)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1605513219471) (:text |defn)
@@ -191,222 +214,210 @@
                           |j $ {} (:type :leaf) (:by |u0) (:at 1605584768421) (:text |20)
           |comp-counter $ {} (:type :expr) (:by |u0) (:at 1605609031986)
             :data $ {}
-              |T $ {} (:type :leaf) (:by |u0) (:at 1605609031986) (:text |def)
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605760339766) (:text |defcomp)
               |j $ {} (:type :leaf) (:by |u0) (:at 1605674950050) (:text |comp-counter)
-              |r $ {} (:type :expr) (:by |u0) (:at 1605609031986)
+              |r $ {} (:type :expr) (:by |u0) (:at 1605760347958)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609042308) (:text |{})
-                  |j $ {} (:type :expr) (:by |u0) (:at 1605609043303)
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |states)
+                  |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |c)
+              |v $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |let)
+                  |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609044215) (:text |:type)
-                      |j $ {} (:type :leaf) (:by |u0) (:at 1605609947872) (:text |:comp)
-                  |r $ {} (:type :expr) (:by |u0) (:at 1605609049191)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609050527) (:text |:args)
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605609050778)
+                      |T $ {} (:type :expr) (:by |u0) (:at 1605760347958)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609050924) (:text |[])
-                  |v $ {} (:type :expr) (:by |u0) (:at 1605609051800)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609054844) (:text |:render)
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605609055113)
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |cursor)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:cursor)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |states)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609056412) (:text |fn)
-                          |j $ {} (:type :expr) (:by |u0) (:at 1605609056694)
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |state)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609058125) (:text |cursor)
-                              |j $ {} (:type :leaf) (:by |u0) (:at 1605609058740) (:text |state)
-                          |r $ {} (:type :expr) (:by |u0) (:at 1605609059386)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609060389) (:text |fn)
-                              |j $ {} (:type :expr) (:by |u0) (:at 1605609060757)
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |either)
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
                                 :data $ {}
-                                  |D $ {} (:type :leaf) (:by |u0) (:at 1605694030830) (:text |c)
-                              |r $ {} (:type :expr) (:by |u0) (:at 1605609063474)
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:data)
+                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |states)
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605760347958)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609063790) (:text |{})
-                                  |j $ {} (:type :expr) (:by |u0) (:at 1605609064026)
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |{})
+                                  |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609066212) (:text |:children)
-                                      |j $ {} (:type :expr) (:by |u0) (:at 1605609068255)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609070214) (:text |{})
-                                  |r $ {} (:type :expr) (:by |u0) (:at 1605609071348)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609073950) (:text |:render)
-                                      |j $ {} (:type :expr) (:by |u0) (:at 1605609074233)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609075593) (:text |fn)
-                                          |j $ {} (:type :expr) (:by |u0) (:at 1605609075871)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609077925) (:text |dict)
-                                          |v $ {} (:type :expr) (:by |u0) (:at 1605674121223)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605674121638) (:text |g)
-                                              |j $ {} (:type :expr) (:by |u0) (:at 1605674122964)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605674123369) (:text |{})
-                                              |r $ {} (:type :expr) (:by |u0) (:at 1605694049201)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605694051095) (:text |{})
-                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605694051590)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694054737) (:text |:type)
-                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605694056496) (:text |:text)
-                                                  |r $ {} (:type :expr) (:by |u0) (:at 1605694057135)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694060822) (:text |:text)
-                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605694470676) (:text "|\"-")
-                                                  |v $ {} (:type :expr) (:by |u0) (:at 1605694070890)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694072374) (:text |:color)
-                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605694072594)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605694073033) (:text |[])
-                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605694073570) (:text |0)
-                                                          |r $ {} (:type :leaf) (:by |u0) (:at 1605694073778) (:text |0)
-                                                          |v $ {} (:type :leaf) (:by |u0) (:at 1605694075046) (:text |100)
-                                                  |x $ {} (:type :expr) (:by |u0) (:at 1605694080333)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694081174) (:text |:align)
-                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605695740668) (:text "|\"center")
-                                                  |n $ {} (:type :expr) (:by |u0) (:at 1605694090984)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694092311) (:text |:x)
-                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605694095302) (:text |0)
-                                              |v $ {} (:type :expr) (:by |u0) (:at 1605694049201)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605694051095) (:text |{})
-                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605694051590)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694054737) (:text |:type)
-                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605694056496) (:text |:text)
-                                                  |r $ {} (:type :expr) (:by |u0) (:at 1605694057135)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694060822) (:text |:text)
-                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605694062127)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605694063112) (:text |str)
-                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605694066391) (:text |c)
-                                                  |v $ {} (:type :expr) (:by |u0) (:at 1605694070890)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694072374) (:text |:color)
-                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605694072594)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605694073033) (:text |[])
-                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605694073570) (:text |0)
-                                                          |r $ {} (:type :leaf) (:by |u0) (:at 1605694073778) (:text |0)
-                                                          |v $ {} (:type :leaf) (:by |u0) (:at 1605694075046) (:text |100)
-                                                  |x $ {} (:type :expr) (:by |u0) (:at 1605694080333)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694081174) (:text |:align)
-                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605695737175) (:text "|\"center")
-                                                  |n $ {} (:type :expr) (:by |u0) (:at 1605694090984)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694092311) (:text |:x)
-                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605694100648) (:text |40)
-                                              |x $ {} (:type :expr) (:by |u0) (:at 1605694049201)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605694051095) (:text |{})
-                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605694051590)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694054737) (:text |:type)
-                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605694056496) (:text |:text)
-                                                  |r $ {} (:type :expr) (:by |u0) (:at 1605694057135)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694060822) (:text |:text)
-                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605694477777) (:text "|\"+")
-                                                  |v $ {} (:type :expr) (:by |u0) (:at 1605694070890)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694072374) (:text |:color)
-                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605694072594)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605694073033) (:text |[])
-                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605694073570) (:text |0)
-                                                          |r $ {} (:type :leaf) (:by |u0) (:at 1605695980668) (:text |90)
-                                                          |v $ {} (:type :leaf) (:by |u0) (:at 1605696384409) (:text |100)
-                                                  |x $ {} (:type :expr) (:by |u0) (:at 1605694080333)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694081174) (:text |:align)
-                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605696449657) (:text "|\"center")
-                                                  |n $ {} (:type :expr) (:by |u0) (:at 1605694090984)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694092311) (:text |:x)
-                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605696426478) (:text |80)
-                                              |n $ {} (:type :expr) (:by |u0) (:at 1605696397583)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605696398121) (:text |{})
-                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605696398595)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605696400483) (:text |:touch-area)
-                                                      |D $ {} (:type :leaf) (:by |u0) (:at 1605696402599) (:text |:type)
-                                                  |r $ {} (:type :expr) (:by |u0) (:at 1605696403185)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605696403898) (:text |:x)
-                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605696406761) (:text |0)
-                                                  |v $ {} (:type :expr) (:by |u0) (:at 1605696407332)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605696411657) (:text |:radius)
-                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605696429953) (:text |10)
-                                                  |x $ {} (:type :expr) (:by |u0) (:at 1605696413707)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605696415036) (:text |:path)
-                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605696415318)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605696415586) (:text |[])
-                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605696416933) (:text "|\"TODO")
-                                                  |y $ {} (:type :expr) (:by |u0) (:at 1605697071009)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605697072679) (:text |:events)
-                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605697073719)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605697073286) (:text |[])
-                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605697394750) (:text |:touch-down)
-                                              |p $ {} (:type :expr) (:by |u0) (:at 1605696397583)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605696398121) (:text |{})
-                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605696398595)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605696400483) (:text |:touch-area)
-                                                      |D $ {} (:type :leaf) (:by |u0) (:at 1605696402599) (:text |:type)
-                                                  |r $ {} (:type :expr) (:by |u0) (:at 1605696403185)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605696403898) (:text |:x)
-                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605696435306) (:text |80)
-                                                  |v $ {} (:type :expr) (:by |u0) (:at 1605696407332)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605696411657) (:text |:radius)
-                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605696431813) (:text |10)
-                                                  |x $ {} (:type :expr) (:by |u0) (:at 1605696413707)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605696415036) (:text |:path)
-                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605696415318)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605696415586) (:text |[])
-                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605697215411) (:text "|\"TODO")
-                                                  |y $ {} (:type :expr) (:by |u0) (:at 1605697085622)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605697085622) (:text |:events)
-                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605697085622)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605697085622) (:text |[])
-                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605697339113) (:text |:touch-down)
-                  |x $ {} (:type :expr) (:by |u0) (:at 1605609090447)
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:count)
+                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |0)
+                  |r $ {} (:type :expr) (:by |u0) (:at 1605760347958)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609092392) (:text |:events)
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605609093168)
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |{})
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609093952) (:text |{})
-                  |n $ {} (:type :expr) (:by |u0) (:at 1605674955308)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605674957437) (:text |:s0)
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605674959358)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605674959771) (:text |{})
-                          |j $ {} (:type :expr) (:by |u0) (:at 1605674959992)
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:children)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |u0) (:at 1605674960715) (:text |:count)
-                              |j $ {} (:type :leaf) (:by |u0) (:at 1605674962224) (:text |0)
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |{})
+                      |r $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:render)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |fn)
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |dict)
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |g)
+                                  |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |{})
+                                  |r $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |{})
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:type)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:touch-area)
+                                      |r $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:x)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |0)
+                                      |v $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:radius)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |10)
+                                      |x $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:path)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760874999) (:text |cursor)
+                                      |y $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:events)
+                                          |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |[])
+                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:touch-down)
+                                  |v $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |{})
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:type)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:touch-area)
+                                      |r $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:x)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |80)
+                                      |v $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:radius)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |10)
+                                      |x $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:path)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760877840) (:text |cursor)
+                                      |y $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:events)
+                                          |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |[])
+                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:touch-down)
+                                  |x $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |{})
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:type)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:text)
+                                      |r $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:x)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |0)
+                                      |v $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:text)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text "|\"-")
+                                      |x $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:color)
+                                          |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |[])
+                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |0)
+                                              |r $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |0)
+                                              |v $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |100)
+                                      |y $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:align)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text "|\"center")
+                                  |y $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |{})
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:type)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:text)
+                                      |r $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:x)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |40)
+                                      |v $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:text)
+                                          |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |str)
+                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |c)
+                                      |x $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:color)
+                                          |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |[])
+                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |0)
+                                              |r $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |0)
+                                              |v $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |100)
+                                      |y $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:align)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text "|\"center")
+                                  |yT $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |{})
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:type)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:text)
+                                      |r $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:x)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |80)
+                                      |v $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:text)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text "|\"+")
+                                      |x $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:color)
+                                          |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |[])
+                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |0)
+                                              |r $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |90)
+                                              |v $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |100)
+                                      |y $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:align)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text "|\"center")
+                      |v $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |:events)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605760347958)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760347958) (:text |{})
           |on-window-event $ {} (:type :expr) (:by |u0) (:at 1605514426898)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1605514426898) (:text |defn)
@@ -414,251 +425,251 @@
               |r $ {} (:type :expr) (:by |u0) (:at 1605514426898)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |u0) (:at 1605514430293) (:text |event)
-              |v $ {} (:type :expr) (:by |u0) (:at 1605514430703)
+              |v $ {} (:type :expr) (:by |u0) (:at 1605759558196)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:by |u0) (:at 1605514431159) (:text |echo)
-                  |j $ {} (:type :leaf) (:by |u0) (:at 1605514431832) (:text |event)
-          |*app-states $ {} (:type :expr) (:by |u0) (:at 1605607758411)
-            :data $ {}
-              |T $ {} (:type :leaf) (:by |u0) (:at 1605607760929) (:text |defatom)
-              |j $ {} (:type :leaf) (:by |u0) (:at 1605607758411) (:text |*app-states)
-              |r $ {} (:type :expr) (:by |u0) (:at 1605607758411)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:by |u0) (:at 1605607763074) (:text |{})
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605514431832) (:text |event)
+                  |D $ {} (:type :leaf) (:by |u0) (:at 1605759589299) (:text |handle-tree-event)
           |comp-data-list $ {} (:type :expr) (:by |u0) (:at 1605608381035)
             :data $ {}
-              |T $ {} (:type :leaf) (:by |u0) (:at 1605608555351) (:text |def)
-              |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
-                  |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:type)
-                      |j $ {} (:type :leaf) (:by |u0) (:at 1605609941383) (:text |:comp)
-                  |r $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:s0)
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
-                          |j $ {} (:type :expr) (:by |u0) (:at 1605696471686)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |u0) (:at 1605696472310) (:text |:size)
-                              |j $ {} (:type :leaf) (:by |u0) (:at 1605696472893) (:text |0)
-                  |v $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:args)
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |[])
-                  |x $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:render)
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |fn)
-                          |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |cursor)
-                              |j $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |state)
-                          |r $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |fn)
-                              |j $ {} (:type :expr) (:by |u0) (:at 1605608381035) (:data $ {})
-                              |r $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
-                                  |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:children)
-                                      |j $ {} (:type :expr) (:by |u0) (:at 1605609197609)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609199195) (:text |->>)
-                                          |j $ {} (:type :expr) (:by |u0) (:at 1605609200504)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609199905) (:text |range)
-                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605609203617) (:text |3)
-                                          |r $ {} (:type :expr) (:by |u0) (:at 1605609205143)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609206240) (:text |map)
-                                              |j $ {} (:type :expr) (:by |u0) (:at 1605609206681)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609207339) (:text |fn)
-                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605609207656)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609208103) (:text |x)
-                                                  |r $ {} (:type :expr) (:by |u0) (:at 1605609231215)
-                                                    :data $ {}
-                                                      |T $ {} (:type :expr) (:by |u0) (:at 1605694421907)
-                                                        :data $ {}
-                                                          |T $ {} (:type :expr) (:by |u0) (:at 1605609210680)
-                                                            :data $ {}
-                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609221505) (:text |merge)
-                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605674969743) (:text |comp-counter)
-                                                              |r $ {} (:type :expr) (:by |u0) (:at 1605609224892)
-                                                                :data $ {}
-                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609225219) (:text |{})
-                                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605609225524)
-                                                                    :data $ {}
-                                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609226164) (:text |:args)
-                                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605609226858)
-                                                                        :data $ {}
-                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609226651) (:text |[])
-                                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605609228218) (:text |x)
-                                                          |D $ {} (:type :leaf) (:by |u0) (:at 1605694423310) (:text |g)
-                                                          |L $ {} (:type :expr) (:by |u0) (:at 1605694423681)
-                                                            :data $ {}
-                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605694424055) (:text |{})
-                                                              |j $ {} (:type :expr) (:by |u0) (:at 1605694425153)
-                                                                :data $ {}
-                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605694425586) (:text |:x)
-                                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605694427037) (:text |0)
-                                                              |r $ {} (:type :expr) (:by |u0) (:at 1605694427490)
-                                                                :data $ {}
-                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605694428408) (:text |:y)
-                                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605694428733)
-                                                                    :data $ {}
-                                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694429494) (:text |*)
-                                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605694432456) (:text |x)
-                                                                      |r $ {} (:type :leaf) (:by |u0) (:at 1605694442923) (:text |30)
-                                                      |D $ {} (:type :leaf) (:by |u0) (:at 1605609232440) (:text |[])
-                                                      |L $ {} (:type :expr) (:by |u0) (:at 1605609233194)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609233662) (:text |str)
-                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605609237601) (:text ||task-)
-                                                          |r $ {} (:type :leaf) (:by |u0) (:at 1605609238193) (:text |x)
-                                          |v $ {} (:type :expr) (:by |u0) (:at 1605609241009)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605669668331) (:text |pairs-map)
-                                  |r $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608634793) (:text |:render)
-                                      |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |fn)
-                                          |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |dict)
-                                          |r $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
-                                              |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:type)
-                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:group)
-                                              |r $ {} (:type :expr) (:by |u0) (:at 1605608967860)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608970172) (:text |:children)
-                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605608971265)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608971542) (:text |[])
-                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605609279465)
-                                                        :data $ {}
-                                                          |T $ {} (:type :expr) (:by |u0) (:at 1605609269716)
-                                                            :data $ {}
-                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609278188) (:text |:group)
-                                                              |D $ {} (:type :leaf) (:by |u0) (:at 1605609281909) (:text |:type)
-                                                          |D $ {} (:type :leaf) (:by |u0) (:at 1605609279980) (:text |{})
-                                                          |j $ {} (:type :expr) (:by |u0) (:at 1605609282628)
-                                                            :data $ {}
-                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609302591) (:text |:children)
-                                                              |j $ {} (:type :expr) (:by |u0) (:at 1605694322665)
-                                                                :data $ {}
-                                                                  |T $ {} (:type :expr) (:by |u0) (:at 1605696582047)
-                                                                    :data $ {}
-                                                                      |T $ {} (:type :expr) (:by |u0) (:at 1605609308104)
-                                                                        :data $ {}
-                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609314395) (:text |->>)
-                                                                          |j $ {} (:type :expr) (:by |u0) (:at 1605609312316)
-                                                                            :data $ {}
-                                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609311200) (:text |range)
-                                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605609313297) (:text |3)
-                                                                          |r $ {} (:type :expr) (:by |u0) (:at 1605609316099)
-                                                                            :data $ {}
-                                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609324994) (:text |map)
-                                                                              |j $ {} (:type :expr) (:by |u0) (:at 1605609326328)
-                                                                                :data $ {}
-                                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609326574) (:text |fn)
-                                                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605609327247)
-                                                                                    :data $ {}
-                                                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609326893) (:text |x)
-                                                                                  |r $ {} (:type :expr) (:by |u0) (:at 1605609330071)
-                                                                                    :data $ {}
-                                                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609335565) (:text |get)
-                                                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605609336989) (:text |dict)
-                                                                                      |r $ {} (:type :expr) (:by |u0) (:at 1605609339967)
-                                                                                        :data $ {}
-                                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609339967) (:text |str)
-                                                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605609339967) (:text ||task-)
-                                                                                          |r $ {} (:type :leaf) (:by |u0) (:at 1605609339967) (:text |x)
-                                                                      |D $ {} (:type :leaf) (:by |u0) (:at 1605696582603) (:text |g)
-                                                                      |L $ {} (:type :expr) (:by |u0) (:at 1605696583090)
-                                                                        :data $ {}
-                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605696583367) (:text |{})
-                                                                          |j $ {} (:type :expr) (:by |u0) (:at 1605696585704)
-                                                                            :data $ {}
-                                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605696587557) (:text |:x)
-                                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605696588062) (:text |40)
-                                                                          |r $ {} (:type :expr) (:by |u0) (:at 1605696588555)
-                                                                            :data $ {}
-                                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605696589386) (:text |:y)
-                                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605696682285) (:text |60)
-                                                                      |P $ {} (:type :leaf) (:by |u0) (:at 1605696613461) (:text |&)
-                                                                  |D $ {} (:type :leaf) (:by |u0) (:at 1605696622537) (:text |[])
-                                                                  |L $ {} (:type :expr) (:by |u0) (:at 1605696483359)
-                                                                    :data $ {}
-                                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |{})
-                                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605696483359)
-                                                                        :data $ {}
-                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |:type)
-                                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |:text)
-                                                                      |r $ {} (:type :expr) (:by |u0) (:at 1605696483359)
-                                                                        :data $ {}
-                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |:x)
-                                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605696654957) (:text |20)
-                                                                      |v $ {} (:type :expr) (:by |u0) (:at 1605696483359)
-                                                                        :data $ {}
-                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |:text)
-                                                                          |j $ {} (:type :expr) (:by |u0) (:at 1605696543702)
-                                                                            :data $ {}
-                                                                              |T $ {} (:type :expr) (:by |u0) (:at 1605696483359)
-                                                                                :data $ {}
-                                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605696507740) (:text |:size)
-                                                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605696518650) (:text |state)
-                                                                              |D $ {} (:type :leaf) (:by |u0) (:at 1605696544923) (:text |str)
-                                                                              |L $ {} (:type :leaf) (:by |u0) (:at 1605696576794) (:text "|\"Size: ")
-                                                                      |x $ {} (:type :expr) (:by |u0) (:at 1605696483359)
-                                                                        :data $ {}
-                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |:color)
-                                                                          |j $ {} (:type :expr) (:by |u0) (:at 1605696483359)
-                                                                            :data $ {}
-                                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |[])
-                                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |0)
-                                                                              |r $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |0)
-                                                                              |v $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |100)
-                                                                      |y $ {} (:type :expr) (:by |u0) (:at 1605696483359)
-                                                                        :data $ {}
-                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |:align)
-                                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text "|\"center")
-                                                                      |t $ {} (:type :expr) (:by |u0) (:at 1605696528636)
-                                                                        :data $ {}
-                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605696529372) (:text |:y)
-                                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605696666622) (:text |20)
-                                              |n $ {} (:type :expr) (:by |u0) (:at 1605696595936)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605696597459) (:text |:x)
-                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605696676684) (:text |0)
-                                              |p $ {} (:type :expr) (:by |u0) (:at 1605696598834)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605696599385) (:text |:y)
-                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605696674465) (:text |0)
-                  |y $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:events)
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605760320635) (:text |defcomp)
               |b $ {} (:type :leaf) (:by |u0) (:at 1605674978697) (:text |comp-data-list)
+              |n $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |store)
+              |t $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |let)
+                  |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |states)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:states)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |store)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |cursor)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:cursor)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |states)
+                      |r $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |state)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |either)
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:data)
+                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |states)
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |{})
+                                  |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:size)
+                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |0)
+                  |r $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |{})
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:children)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |->>)
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |range)
+                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |3)
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |map)
+                                  |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |fn)
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |x)
+                                      |r $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |[])
+                                          |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |str)
+                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text ||task-)
+                                              |r $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |x)
+                                          |r $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |g)
+                                              |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |{})
+                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:x)
+                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |0)
+                                                  |r $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:y)
+                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |*)
+                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |x)
+                                                          |r $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |30)
+                                              |r $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |merge)
+                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |comp-counter)
+                                                  |r $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |{})
+                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:args)
+                                                          |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |[])
+                                                              |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |>>)
+                                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |states)
+                                                                  |r $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |x)
+                                                              |r $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |x)
+                              |v $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |pairs-map)
+                      |r $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:render)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |fn)
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |dict)
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |{})
+                                  |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:type)
+                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:group)
+                                  |r $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:x)
+                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |0)
+                                  |v $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:y)
+                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |0)
+                                  |x $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:children)
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |[])
+                                          |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |{})
+                                              |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:type)
+                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:group)
+                                              |r $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:children)
+                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |[])
+                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |{})
+                                                          |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:type)
+                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:text)
+                                                          |r $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:x)
+                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |20)
+                                                          |v $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:y)
+                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |20)
+                                                          |x $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:text)
+                                                              |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |str)
+                                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text "|\"Size: ")
+                                                                  |r $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:size)
+                                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |state)
+                                                          |y $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:color)
+                                                              |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |[])
+                                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |0)
+                                                                  |r $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |0)
+                                                                  |v $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |100)
+                                                          |yT $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:align)
+                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text "|\"center")
+                                                      |r $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |g)
+                                                          |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |{})
+                                                              |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:x)
+                                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |40)
+                                                              |r $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:y)
+                                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |60)
+                                                          |r $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |&)
+                                                          |v $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |->>)
+                                                              |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |range)
+                                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |3)
+                                                              |r $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |map)
+                                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |fn)
+                                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |x)
+                                                                      |r $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |get)
+                                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |dict)
+                                                                          |r $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |str)
+                                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text ||task-)
+                                                                              |r $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |x)
+                      |v $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |:events)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605760326837)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760326837) (:text |{})
           |render-shape $ {} (:type :expr) (:by |u0) (:at 1605584374701)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1605584374701) (:text |defn)
@@ -675,10 +686,6 @@
                       |T $ {} (:type :expr) (:by |u0) (:at 1605607710368)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |u0) (:at 1605607715052) (:text |expand-tree)
-                          |j $ {} (:type :expr) (:by |u0) (:at 1605607766890)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |u0) (:at 1605607757676) (:text |*app-states)
-                              |D $ {} (:type :leaf) (:by |u0) (:at 1605607768774) (:text |deref)
                           |b $ {} (:type :expr) (:by |u0) (:at 1605607791307)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |u0) (:at 1605607793219) (:text |merge)
@@ -692,15 +699,16 @@
                                       |j $ {} (:type :expr) (:by |u0) (:at 1605607807299)
                                         :data $ {}
                                           |T $ {} (:type :leaf) (:by |u0) (:at 1605607807130) (:text |[])
-                          |f $ {} (:type :expr) (:by |u0) (:at 1605607787081)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |u0) (:at 1605607787331) (:text |[])
+                                          |j $ {} (:type :expr) (:by |u0) (:at 1605758311366)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605758313389) (:text |deref)
+                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605758345965) (:text |*store)
                       |D $ {} (:type :leaf) (:by |u0) (:at 1605608888090) (:text |tree)
                   |D $ {} (:type :leaf) (:by |u0) (:at 1605608882131) (:text |&let)
                   |j $ {} (:type :expr) (:by |u0) (:at 1605608889991)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |u0) (:at 1605608894244) (:text |reset!)
-                      |j $ {} (:type :leaf) (:by |u0) (:at 1605608901640) (:text |*app-states)
+                      |j $ {} (:type :leaf) (:by |u0) (:at 1605759253265) (:text |*tree-state)
                       |r $ {} (:type :leaf) (:by |u0) (:at 1605608903716) (:text |tree)
                   |r $ {} (:type :expr) (:by |u0) (:at 1605608932257)
                     :data $ {}
@@ -734,6 +742,42 @@
                       |T $ {} (:type :leaf) (:by |u0) (:at 1605670244183) (:text |echo)
                       |j $ {} (:type :leaf) (:by |u0) (:at 1605670247393) (:text "|\"tree:")
                       |D $ {} (:type :leaf) (:by |u0) (:at 1605694189811) (:text |;)
+                  |t $ {} (:type :expr) (:by |u0) (:at 1605760098501)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760099567) (:text |echo)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605760101295)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760104629) (:text |macroexpand)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605760105960)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760107232) (:text |quote)
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605760107580)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760108679) (:text |defcomp)
+                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605760121671) (:text |comp-name)
+                                  |r $ {} (:type :expr) (:by |u0) (:at 1605760127288)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760129352) (:text |a)
+                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605760129757) (:text |b)
+                                  |v $ {} (:type :expr) (:by |u0) (:at 1605760131628)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760131945) (:text |{})
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605760132778)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760136777) (:text |:children)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760138052) (:text |nil)
+                                      |r $ {} (:type :expr) (:by |u0) (:at 1605760138501)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760139261) (:text |:tree)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760139811) (:text |nil)
+                                      |v $ {} (:type :expr) (:by |u0) (:at 1605760140678)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760142151) (:text |:events)
+                                          |j $ {} (:type :expr) (:by |u0) (:at 1605760145117)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605760145457) (:text |{})
+                      |b $ {} (:type :leaf) (:by |u0) (:at 1605760158121) (:text "|\"Generated")
+                      |D $ {} (:type :leaf) (:by |u0) (:at 1605760310456) (:text |;)
               |vT $ {} (:type :expr) (:by |u0) (:at 1605694179060)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |u0) (:at 1605694179060) (:text |render-rotate)
@@ -915,6 +959,56 @@
             |T $ {} (:type :leaf) (:by |u0) (:at 1605513215399) (:text |ns)
             |j $ {} (:type :leaf) (:by |u0) (:at 1605513215399) (:text |phlox.core)
         :defs $ {}
+          |>> $ {} (:type :expr) (:by |u0) (:at 1605758428389)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605758428389) (:text |defn)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605758428389) (:text |>>)
+              |r $ {} (:type :expr) (:by |u0) (:at 1605758428389)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605758434695) (:text |states)
+                  |j $ {} (:type :leaf) (:by |u0) (:at 1605758434900) (:text |k)
+              |v $ {} (:type :expr) (:by |u0) (:at 1605758435448)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605758439347) (:text |let)
+                  |j $ {} (:type :expr) (:by |u0) (:at 1605758439563)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |u0) (:at 1605758440097)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605758443841) (:text |parent-cursor)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605758521543)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |u0) (:at 1605758444053)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605758445427) (:text |:cursor)
+                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605758446183) (:text |states)
+                              |D $ {} (:type :leaf) (:by |u0) (:at 1605758523695) (:text |either)
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605758524552)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605758525248) (:text |[])
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605758447575)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605758450449) (:text |branch)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605758451192)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605758451656) (:text |get)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605758453028) (:text |states)
+                              |r $ {} (:type :leaf) (:by |u0) (:at 1605758453326) (:text |k)
+                  |r $ {} (:type :expr) (:by |u0) (:at 1605758459796)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605758460525) (:text |assoc)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605758461045)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605758462469) (:text |either)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605758464407) (:text |branch)
+                          |r $ {} (:type :expr) (:by |u0) (:at 1605758465300)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605758465693) (:text |{})
+                      |r $ {} (:type :leaf) (:by |u0) (:at 1605758471070) (:text |:cursor)
+                      |v $ {} (:type :expr) (:by |u0) (:at 1605758471830)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605758472815) (:text |append)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605758652526) (:text |parent-cursor)
+                          |r $ {} (:type :leaf) (:by |u0) (:at 1605758495912) (:text |k)
           |wrap-kwd-in-list $ {} (:type :expr) (:by |u0) (:at 1605695105039)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1605695106489) (:text |defn)
@@ -925,18 +1019,114 @@
               |p $ {} (:type :expr) (:by |u0) (:at 1605695213429)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |u0) (:at 1605695213931) (:text |map)
-                  |j $ {} (:type :leaf) (:by |u0) (:at 1605695216534) (:text |wrap-keywords-in-path)
+                  |j $ {} (:type :leaf) (:by |u0) (:at 1605759421514) (:text |wrap-kwd-in-path)
                   |r $ {} (:type :leaf) (:by |u0) (:at 1605695217978) (:text |xs0)
           |*tree-state $ {} (:type :expr) (:by |u0) (:at 1605597974750)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1605597979250) (:text |defatom)
               |j $ {} (:type :leaf) (:by |u0) (:at 1605604861087) (:text |*tree-state)
               |r $ {} (:type :leaf) (:by |u0) (:at 1605597991156) (:text |nil)
+          |wrap-kwd-in-event $ {} (:type :expr) (:by |u0) (:at 1605759393966)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605759393966) (:text |defn)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605759393966) (:text |wrap-kwd-in-event)
+              |r $ {} (:type :expr) (:by |u0) (:at 1605759393966)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605759461385) (:text |case)
+                  |j $ {} (:type :expr) (:by |u0) (:at 1605759461581)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605759463433) (:text |type-of)
+                      |j $ {} (:type :leaf) (:by |u0) (:at 1605759469904) (:text |x)
+                  |r $ {} (:type :expr) (:by |u0) (:at 1605759471882)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605759479548) (:text |:map)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605759503500)
+                        :data $ {}
+                          |T $ {} (:type :expr) (:by |u0) (:at 1605759498950)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605759502783) (:text |map-kv)
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605759507252)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605759507544) (:text |fn)
+                                  |j $ {} (:type :expr) (:by |u0) (:at 1605759507774)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605759507902) (:text |k)
+                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605759508454) (:text |v)
+                                  |r $ {} (:type :expr) (:by |u0) (:at 1605759509564)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605759517979) (:text |[])
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605759520347)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605759520078) (:text |v)
+                                          |D $ {} (:type :leaf) (:by |u0) (:at 1605759522783) (:text |wrap-kwd-in-event)
+                                      |b $ {} (:type :expr) (:by |u0) (:at 1605759524180)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605759525387) (:text |if)
+                                          |j $ {} (:type :expr) (:by |u0) (:at 1605759525664)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605759528158) (:text |string?)
+                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605759529656) (:text |k)
+                                          |r $ {} (:type :expr) (:by |u0) (:at 1605759535846)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605759535677) (:text |turn-keyword)
+                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605759537430) (:text |k)
+                                          |v $ {} (:type :leaf) (:by |u0) (:at 1605759538463) (:text |k)
+                          |D $ {} (:type :leaf) (:by |u0) (:at 1605759504298) (:text |->>)
+                          |L $ {} (:type :leaf) (:by |u0) (:at 1605759505435) (:text |x)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605759543311)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605759544625) (:text |pairs-map)
+                  |v $ {} (:type :expr) (:by |u0) (:at 1605759480118)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605759480922) (:text |:vec)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605759493840)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605759494180) (:text |map)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605759495701) (:text |wrap-kwd-in-event)
+                          |r $ {} (:type :leaf) (:by |u0) (:at 1605759497186) (:text |x)
+                  |x $ {} (:type :expr) (:by |u0) (:at 1605759482433)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |u0) (:at 1605759489203)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605759489203) (:text |type-of)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605759489203) (:text |x)
+                      |j $ {} (:type :leaf) (:by |u0) (:at 1605759490912) (:text |x)
+              |n $ {} (:type :expr) (:by |u0) (:at 1605759467555)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605759467802) (:text |x)
           |handle-tree-event $ {} (:type :expr) (:by |u0) (:at 1605598323672)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1605598323672) (:text |defn)
               |j $ {} (:type :leaf) (:by |u0) (:at 1605604731439) (:text |handle-tree-event)
-              |r $ {} (:type :expr) (:by |u0) (:at 1605598323672) (:data $ {})
+              |r $ {} (:type :expr) (:by |u0) (:at 1605598323672)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605759602439) (:text |event)
+              |v $ {} (:type :expr) (:by |u0) (:at 1605759603495)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605759603862) (:text |let)
+                  |j $ {} (:type :expr) (:by |u0) (:at 1605759617280)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |u0) (:at 1605759604521)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605759604935) (:text |e)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605759607962)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605759612969) (:text |wrap-kwd-in-event)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605759615257) (:text |event)
+                  |r $ {} (:type :expr) (:by |u0) (:at 1605759640854)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |u0) (:at 1605759618546)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605759622772) (:text |echo)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605759624189) (:text |e)
+                      |D $ {} (:type :leaf) (:by |u0) (:at 1605759677498) (:text |if)
+                      |L $ {} (:type :expr) (:by |u0) (:at 1605759642283)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605759646507) (:text |some?)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605759647343)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605759667268) (:text |:path)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605759670497) (:text |e)
           |get-shape-tree $ {} (:type :expr) (:by |u0) (:at 1605597959027)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1605597959027) (:text |defn)
@@ -1023,55 +1213,8 @@
                                   |r $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |path)
                                   |v $ {} (:type :expr) (:by |u0) (:at 1605671865037)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |wrap-keywords-in-path)
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605759431380) (:text |wrap-kwd-in-path)
                                       |j $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |path)
-          |wrap-keywords-in-path $ {} (:type :expr) (:by |u0) (:at 1605603183115)
-            :data $ {}
-              |T $ {} (:type :leaf) (:by |u0) (:at 1605603183115) (:text |defn)
-              |j $ {} (:type :leaf) (:by |u0) (:at 1605603183115) (:text |wrap-keywords-in-path)
-              |r $ {} (:type :expr) (:by |u0) (:at 1605603183115)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:by |u0) (:at 1605695152463) (:text |x)
-              |v $ {} (:type :expr) (:by |u0) (:at 1605695143111)
-                :data $ {}
-                  |T $ {} (:type :expr) (:by |u0) (:at 1605695155778)
-                    :data $ {}
-                      |T $ {} (:type :expr) (:by |u0) (:at 1605695111520)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605695105039) (:text |wrap-kwd-in-list)
-                          |j $ {} (:type :leaf) (:by |u0) (:at 1605695153840) (:text |x)
-                      |D $ {} (:type :leaf) (:by |u0) (:at 1605695156706) (:text |:list)
-                  |D $ {} (:type :leaf) (:by |u0) (:at 1605695144979) (:text |case)
-                  |L $ {} (:type :expr) (:by |u0) (:at 1605695146276)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605695148252) (:text |type-of)
-                      |j $ {} (:type :leaf) (:by |u0) (:at 1605695150918) (:text |x)
-                  |j $ {} (:type :expr) (:by |u0) (:at 1605695157930)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605695159806) (:text |:map)
-                      |j $ {} (:type :leaf) (:by |u0) (:at 1605695160030) (:text |)
-                      |b $ {} (:type :expr) (:by |u0) (:at 1605695225982)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605695229662) (:text |wrap-kwd-in-map)
-                          |j $ {} (:type :leaf) (:by |u0) (:at 1605695231067) (:text |x)
-                  |r $ {} (:type :expr) (:by |u0) (:at 1605695161452)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605695169771) (:text |:keyword)
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605695179311)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605695179311) (:text |str)
-                          |j $ {} (:type :leaf) (:by |u0) (:at 1605695179311) (:text "|\":")
-                          |r $ {} (:type :expr) (:by |u0) (:at 1605695179311)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |u0) (:at 1605695179311) (:text |turn-str)
-                              |j $ {} (:type :leaf) (:by |u0) (:at 1605695179311) (:text |x0)
-                  |v $ {} (:type :expr) (:by |u0) (:at 1605695282923)
-                    :data $ {}
-                      |T $ {} (:type :expr) (:by |u0) (:at 1605695281392)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605695280381) (:text |type-of)
-                          |j $ {} (:type :leaf) (:by |u0) (:at 1605695282061) (:text |x)
-                      |j $ {} (:type :leaf) (:by |u0) (:at 1605695284947) (:text |x)
           |wrap-kwd-in-map $ {} (:type :expr) (:by |u0) (:at 1605695232281)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1605695232281) (:text |defn)
@@ -1098,11 +1241,11 @@
                               |j $ {} (:type :expr) (:by |u0) (:at 1605695255522)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |u0) (:at 1605695253620) (:text |k)
-                                  |D $ {} (:type :leaf) (:by |u0) (:at 1605695261344) (:text |wrap-keywords-in-path)
+                                  |D $ {} (:type :leaf) (:by |u0) (:at 1605759415983) (:text |wrap-kwd-in-path)
                               |r $ {} (:type :expr) (:by |u0) (:at 1605695263619)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |u0) (:at 1605695253983) (:text |v)
-                                  |D $ {} (:type :leaf) (:by |u0) (:at 1605695266180) (:text |wrap-keywords-in-path)
+                                  |D $ {} (:type :leaf) (:by |u0) (:at 1605759417412) (:text |wrap-kwd-in-path)
                   |b $ {} (:type :leaf) (:by |u0) (:at 1605695249628) (:text |xs)
                   |r $ {} (:type :expr) (:by |u0) (:at 1605695268669)
                     :data $ {}
@@ -1114,8 +1257,6 @@
               |r $ {} (:type :expr) (:by |u0) (:at 1605597943340)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |u0) (:at 1605604893264) (:text |tree)
-                  |j $ {} (:type :leaf) (:by |u0) (:at 1605604897286) (:text |coord)
-                  |r $ {} (:type :leaf) (:by |u0) (:at 1605605937234) (:text |states)
               |v $ {} (:type :expr) (:by |u0) (:at 1605604898929)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |u0) (:at 1605605072834) (:text |case)
@@ -1187,11 +1328,7 @@
                                       |j $ {} (:type :expr) (:by |u0) (:at 1605608213363)
                                         :data $ {}
                                           |T $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |apply)
-                                          |j $ {} (:type :expr) (:by |u0) (:at 1605608213363)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |renderer)
-                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |coord)
-                                              |r $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |states)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |renderer)
                                           |r $ {} (:type :expr) (:by |u0) (:at 1605608213363)
                                             :data $ {}
                                               |T $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |:args)
@@ -1226,8 +1363,6 @@
                                                             :data $ {}
                                                               |T $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |expand-tree)
                                                               |j $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |v)
-                                                              |r $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |coord)
-                                                              |v $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |states)
                                                       |r $ {} (:type :expr) (:by |u0) (:at 1605671008950)
                                                         :data $ {}
                                                           |T $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |[])
@@ -1263,8 +1398,6 @@
                                         :data $ {}
                                           |T $ {} (:type :leaf) (:by |u0) (:at 1605605578703) (:text |expand-tree)
                                           |j $ {} (:type :leaf) (:by |u0) (:at 1605605580481) (:text |x)
-                                          |r $ {} (:type :leaf) (:by |u0) (:at 1605605582954) (:text |coord)
-                                          |v $ {} (:type :leaf) (:by |u0) (:at 1605668480262) (:text |states)
                                   |r $ {} (:type :leaf) (:by |u0) (:at 1605605586240) (:text |xs)
                   |x $ {} (:type :expr) (:by |u0) (:at 1605605079234)
                     :data $ {}
@@ -1308,6 +1441,121 @@
                           |j $ {} (:type :leaf) (:by |u0) (:at 1605672956751) (:text |xs)
                   |D $ {} (:type :leaf) (:by |u0) (:at 1605672995895) (:text |merge)
                   |L $ {} (:type :leaf) (:by |u0) (:at 1605672996528) (:text |props)
+          |wrap-kwd-in-path $ {} (:type :expr) (:by |u0) (:at 1605603183115)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605603183115) (:text |defn)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605759411025) (:text |wrap-kwd-in-path)
+              |r $ {} (:type :expr) (:by |u0) (:at 1605603183115)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605695152463) (:text |x)
+              |v $ {} (:type :expr) (:by |u0) (:at 1605695143111)
+                :data $ {}
+                  |T $ {} (:type :expr) (:by |u0) (:at 1605695155778)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |u0) (:at 1605695111520)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605695105039) (:text |wrap-kwd-in-list)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605695153840) (:text |x)
+                      |D $ {} (:type :leaf) (:by |u0) (:at 1605695156706) (:text |:list)
+                  |D $ {} (:type :leaf) (:by |u0) (:at 1605695144979) (:text |case)
+                  |L $ {} (:type :expr) (:by |u0) (:at 1605695146276)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605695148252) (:text |type-of)
+                      |j $ {} (:type :leaf) (:by |u0) (:at 1605695150918) (:text |x)
+                  |j $ {} (:type :expr) (:by |u0) (:at 1605695157930)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605695159806) (:text |:map)
+                      |j $ {} (:type :leaf) (:by |u0) (:at 1605695160030) (:text |)
+                      |b $ {} (:type :expr) (:by |u0) (:at 1605695225982)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605695229662) (:text |wrap-kwd-in-map)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605695231067) (:text |x)
+                  |r $ {} (:type :expr) (:by |u0) (:at 1605695161452)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605695169771) (:text |:keyword)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605695179311)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605695179311) (:text |str)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605695179311) (:text "|\":")
+                          |r $ {} (:type :expr) (:by |u0) (:at 1605695179311)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605695179311) (:text |turn-str)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605695179311) (:text |x0)
+                  |v $ {} (:type :expr) (:by |u0) (:at 1605695282923)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |u0) (:at 1605695281392)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605695280381) (:text |type-of)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605695282061) (:text |x)
+                      |j $ {} (:type :leaf) (:by |u0) (:at 1605695284947) (:text |x)
+          |defcomp $ {} (:type :expr) (:by |u0) (:at 1605759847851)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605759851636) (:text |defmacro)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605759847851) (:text |defcomp)
+              |r $ {} (:type :expr) (:by |u0) (:at 1605759847851)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760377393) (:text |comp-name)
+                  |j $ {} (:type :leaf) (:by |u0) (:at 1605759858115) (:text |args)
+                  |r $ {} (:type :leaf) (:by |u0) (:at 1605759860251) (:text |&)
+                  |v $ {} (:type :leaf) (:by |u0) (:at 1605759861253) (:text |body)
+              |v $ {} (:type :expr) (:by |u0) (:at 1605759865689)
+                :data $ {}
+                  |T $ {} (:type :expr) (:by |u0) (:at 1605759862928)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605759864618) (:text |{})
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605759869798)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605759874499) (:text |:type)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605759875677) (:text |:comp)
+                      |r $ {} (:type :expr) (:by |u0) (:at 1605759876099)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605759877632) (:text |:args)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605759877908)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605759878123) (:text |[])
+                      |v $ {} (:type :expr) (:by |u0) (:at 1605759879972)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605759883178) (:text |:render)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605759883584)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605759885281) (:text |fn)
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605760070793)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760070793) (:text |~)
+                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605760070793) (:text |args)
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605759996299)
+                                :data $ {}
+                                  |T $ {} (:type :expr) (:by |u0) (:at 1605760002480)
+                                    :data $ {}
+                                      |T $ {} (:type :expr) (:by |u0) (:at 1605760006066)
+                                        :data $ {}
+                                          |T $ {} (:type :expr) (:by |u0) (:at 1605759930735)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605759933355) (:text |~@)
+                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605759934585) (:text |body)
+                                          |D $ {} (:type :leaf) (:by |u0) (:at 1605760006683) (:text |do)
+                                      |D $ {} (:type :leaf) (:by |u0) (:at 1605760003339) (:text |ret)
+                                  |D $ {} (:type :leaf) (:by |u0) (:at 1605760000761) (:text |&let)
+                                  |j $ {} (:type :expr) (:by |u0) (:at 1605760033146)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605760035501) (:text |assert)
+                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605760046781) (:text "|\"component returns a map")
+                                      |r $ {} (:type :expr) (:by |u0) (:at 1605760047894)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760049080) (:text |map?)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605760049686) (:text |ret)
+                                  |r $ {} (:type :leaf) (:by |u0) (:at 1605760051191) (:text |ret)
+                      |n $ {} (:type :expr) (:by |u0) (:at 1605760163680)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605760164658) (:text |:name)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605760389228)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |u0) (:at 1605760167598)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605760381586) (:text |comp-name)
+                                  |D $ {} (:type :leaf) (:by |u0) (:at 1605760174495) (:text |turn-keyword)
+                              |D $ {} (:type :leaf) (:by |u0) (:at 1605760389794) (:text |~)
+                  |D $ {} (:type :leaf) (:by |u0) (:at 1605759868754) (:text |quote-replace)
         :proc $ {} (:type :expr) (:by |u0) (:at 1605513215399) (:data $ {})
         :configs $ {}
       |phlox.complex $ {}

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -24,20 +24,200 @@
                         |r $ {} (:type :leaf) (:by |u0) (:at 1605546256719) (:text |c-)
                         |v $ {} (:type :leaf) (:by |u0) (:at 1605547636747) (:text |c*)
                         |x $ {} (:type :leaf) (:by |u0) (:at 1605547638757) (:text |rad-point)
+                |b $ {} (:type :expr) (:by |u0) (:at 1605607717413)
+                  :data $ {}
+                    |T $ {} (:type :leaf) (:by |u0) (:at 1605607718001) (:text |[])
+                    |j $ {} (:type :leaf) (:by |u0) (:at 1605607726395) (:text |phlox.core)
+                    |r $ {} (:type :leaf) (:by |u0) (:at 1605607728453) (:text |:refer)
+                    |v $ {} (:type :expr) (:by |u0) (:at 1605607728729)
+                      :data $ {}
+                        |T $ {} (:type :leaf) (:by |u0) (:at 1605607728938) (:text |[])
+                        |j $ {} (:type :leaf) (:by |u0) (:at 1605607737932) (:text |expand-tree)
+                        |r $ {} (:type :leaf) (:by |u0) (:at 1605608551175) (:text |def)
+                        |v $ {} (:type :leaf) (:by |u0) (:at 1605608929110) (:text |get-shape-tree)
         :defs $ {}
+          |comp-todo-list $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605608555351) (:text |def)
+              |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
+                  |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:type)
+                      |j $ {} (:type :leaf) (:by |u0) (:at 1605609941383) (:text |:comp)
+                  |r $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:s0)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
+                  |v $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:args)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |[])
+                  |x $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:render)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |fn)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |cursor)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |state)
+                          |r $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |fn)
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |&)
+                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |args)
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
+                                  |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:children)
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605609174711)
+                                        :data $ {}
+                                          |T $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
+                                              |j $ {} (:type :expr) (:by |u0) (:at 1605609164723)
+                                                :data $ {}
+                                                  |T $ {} (:type :expr) (:by |u0) (:at 1605609025517)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609026887) (:text |merge)
+                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605609030641) (:text |comp-todo-task)
+                                                      |r $ {} (:type :expr) (:by |u0) (:at 1605609185819)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609186991) (:text |{})
+                                                          |j $ {} (:type :expr) (:by |u0) (:at 1605609187389)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609188635) (:text |:args)
+                                                              |j $ {} (:type :expr) (:by |u0) (:at 1605609189493)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609189733) (:text |[])
+                                                  |D $ {} (:type :leaf) (:by |u0) (:at 1605609172313) (:text |:header)
+                                          |D $ {} (:type :leaf) (:by |u0) (:at 1605609175555) (:text |merge)
+                                          |j $ {} (:type :expr) (:by |u0) (:at 1605609197609)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609199195) (:text |->>)
+                                              |j $ {} (:type :expr) (:by |u0) (:at 1605609200504)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609199905) (:text |range)
+                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605609203617) (:text |3)
+                                              |r $ {} (:type :expr) (:by |u0) (:at 1605609205143)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609206240) (:text |map)
+                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605609206681)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609207339) (:text |fn)
+                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605609207656)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609208103) (:text |x)
+                                                      |r $ {} (:type :expr) (:by |u0) (:at 1605609231215)
+                                                        :data $ {}
+                                                          |T $ {} (:type :expr) (:by |u0) (:at 1605609210680)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609221505) (:text |merge)
+                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605609223897) (:text |comp-todo-task)
+                                                              |r $ {} (:type :expr) (:by |u0) (:at 1605609224892)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609225219) (:text |{})
+                                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605609225524)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609226164) (:text |:args)
+                                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605609226858)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609226651) (:text |[])
+                                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605609228218) (:text |x)
+                                                          |D $ {} (:type :leaf) (:by |u0) (:at 1605609232440) (:text |[])
+                                                          |L $ {} (:type :expr) (:by |u0) (:at 1605609233194)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609233662) (:text |str)
+                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605609237601) (:text ||task-)
+                                                              |r $ {} (:type :leaf) (:by |u0) (:at 1605609238193) (:text |x)
+                                              |v $ {} (:type :expr) (:by |u0) (:at 1605609241009)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609257286) (:text |pair-map)
+                                  |r $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608634793) (:text |:render)
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |fn)
+                                          |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |dict)
+                                          |r $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
+                                              |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:type)
+                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:group)
+                                              |r $ {} (:type :expr) (:by |u0) (:at 1605608967860)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608970172) (:text |:children)
+                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605608971265)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608971542) (:text |[])
+                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605609279465)
+                                                        :data $ {}
+                                                          |T $ {} (:type :expr) (:by |u0) (:at 1605609269716)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609278188) (:text |:group)
+                                                              |D $ {} (:type :leaf) (:by |u0) (:at 1605609281909) (:text |:type)
+                                                          |D $ {} (:type :leaf) (:by |u0) (:at 1605609279980) (:text |{})
+                                                          |j $ {} (:type :expr) (:by |u0) (:at 1605609282628)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609302591) (:text |:children)
+                                                              |j $ {} (:type :expr) (:by |u0) (:at 1605609308104)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609314395) (:text |->>)
+                                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605609312316)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609311200) (:text |range)
+                                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605609313297) (:text |3)
+                                                                  |r $ {} (:type :expr) (:by |u0) (:at 1605609316099)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609324994) (:text |map)
+                                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605609326328)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609326574) (:text |fn)
+                                                                          |j $ {} (:type :expr) (:by |u0) (:at 1605609327247)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609326893) (:text |x)
+                                                                          |r $ {} (:type :expr) (:by |u0) (:at 1605609330071)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609335565) (:text |get)
+                                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605609336989) (:text |dict)
+                                                                              |r $ {} (:type :expr) (:by |u0) (:at 1605609339967)
+                                                                                :data $ {}
+                                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609339967) (:text |str)
+                                                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605609339967) (:text ||task-)
+                                                                                  |r $ {} (:type :leaf) (:by |u0) (:at 1605609339967) (:text |x)
+                                                      |b $ {} (:type :expr) (:by |u0) (:at 1605609290097)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609290854) (:text |get)
+                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605609292438) (:text |dict)
+                                                          |r $ {} (:type :leaf) (:by |u0) (:at 1605609295058) (:text |:header)
+                  |y $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:events)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
+              |b $ {} (:type :leaf) (:by |u0) (:at 1605608578523) (:text |comp-todo-list)
           |main! $ {} (:type :expr) (:by |u0) (:at 1605513219471)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1605513219471) (:text |defn)
               |j $ {} (:type :leaf) (:by |u0) (:at 1605513219471) (:text |main!)
               |r $ {} (:type :expr) (:by |u0) (:at 1605513219471) (:data $ {})
-              |v $ {} (:type :expr) (:by |u0) (:at 1605513267614)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:by |u0) (:at 1605513268415) (:text |println)
-                  |j $ {} (:type :leaf) (:by |u0) (:at 1605513271558) (:text "|\"hello world")
-              |x $ {} (:type :expr) (:by |u0) (:at 1605513316241)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:by |u0) (:at 1605513318167) (:text |println)
-                  |j $ {} (:type :leaf) (:by |u0) (:at 1605513320243) (:text "|\"working")
               |t $ {} (:type :expr) (:by |u0) (:at 1605513414903)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |u0) (:at 1605513431333) (:text |init-canvas)
@@ -58,7 +238,282 @@
                           |j $ {} (:type :leaf) (:by |u0) (:at 1605547830277) (:text |800)
               |u $ {} (:type :expr) (:by |u0) (:at 1605513458827)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:by |u0) (:at 1605513461717) (:text |render-shape)
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605584388019) (:text |render-shape)
+              |w $ {} (:type :expr) (:by |u0) (:at 1605584085868)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605584087048) (:text |echo)
+                  |j $ {} (:type :leaf) (:by |u0) (:at 1605584094398) (:text "|\"app started.")
+          |render-rotate $ {} (:type :expr) (:by |u0) (:at 1605584419081)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605584419081) (:text |defn)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605584419081) (:text |render-rotate)
+              |r $ {} (:type :expr) (:by |u0) (:at 1605584419081) (:data $ {})
+              |v $ {} (:type :expr) (:by |u0) (:at 1605584620506)
+                :data $ {}
+                  |T $ {} (:type :expr) (:by |u0) (:at 1605584463002)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605584463989) (:text |draw-canvas)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605584475557)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |g)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605584475557)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |{})
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605584475557)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |:x)
+                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605584757822) (:text |200)
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605584475557)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |:y)
+                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605584753921) (:text |300)
+                          |r $ {} (:type :expr) (:by |u0) (:at 1605584475557)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |{})
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605584475557)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |:type)
+                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |:polyline)
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605584475557)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |:from)
+                                  |j $ {} (:type :expr) (:by |u0) (:at 1605584475557)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |[])
+                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605585086768) (:text |100)
+                                      |r $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |0)
+                              |v $ {} (:type :expr) (:by |u0) (:at 1605584475557)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605584535243) (:text |:relative-stops)
+                                  |j $ {} (:type :expr) (:by |u0) (:at 1605584551378)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605584554477) (:text |->>)
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605584555414)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605584555047) (:text |range)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605585377685) (:text |200)
+                                      |r $ {} (:type :expr) (:by |u0) (:at 1605584559288)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605584561021) (:text |map)
+                                          |j $ {} (:type :expr) (:by |u0) (:at 1605584561300)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605584561513) (:text |fn)
+                                              |j $ {} (:type :expr) (:by |u0) (:at 1605584561796)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605584562022) (:text |x)
+                                              |r $ {} (:type :expr) (:by |u0) (:at 1605584563160)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605584571331) (:text |c*)
+                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605584572005)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605584572161) (:text |[])
+                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605584726168)
+                                                        :data $ {}
+                                                          |T $ {} (:type :expr) (:by |u0) (:at 1605584629746)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605584573080) (:text |x)
+                                                              |D $ {} (:type :leaf) (:by |u0) (:at 1605584630888) (:text |*)
+                                                              |L $ {} (:type :leaf) (:by |u0) (:at 1605584648344) (:text |r0)
+                                                          |D $ {} (:type :leaf) (:by |u0) (:at 1605584727229) (:text |+)
+                                                          |L $ {} (:type :leaf) (:by |u0) (:at 1605584728918) (:text |b0)
+                                                      |r $ {} (:type :leaf) (:by |u0) (:at 1605584608562) (:text |0)
+                                                  |r $ {} (:type :expr) (:by |u0) (:at 1605584609681)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605584609681) (:text |rad-point)
+                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605584672754)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605584609681) (:text |x)
+                                                          |D $ {} (:type :leaf) (:by |u0) (:at 1605584674962) (:text |*)
+                                                          |L $ {} (:type :leaf) (:by |u0) (:at 1605584677385) (:text |r1)
+                                                          |H $ {} (:type :leaf) (:by |u0) (:at 1605585139450) (:text |&PI)
+                              |x $ {} (:type :expr) (:by |u0) (:at 1605584475557)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |:stroke-color)
+                                  |j $ {} (:type :expr) (:by |u0) (:at 1605584475557)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |[])
+                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |0)
+                                      |r $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |80)
+                                      |v $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |60)
+                              |y $ {} (:type :expr) (:by |u0) (:at 1605584475557)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |:line-width)
+                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |2)
+                              |yT $ {} (:type :expr) (:by |u0) (:at 1605584475557)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |:line-join)
+                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |:round)
+                              |yj $ {} (:type :expr) (:by |u0) (:at 1605584475557)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |:skip-first?)
+                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605584735227) (:text |true)
+                  |D $ {} (:type :leaf) (:by |u0) (:at 1605584621136) (:text |let)
+                  |L $ {} (:type :expr) (:by |u0) (:at 1605584621351)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |u0) (:at 1605584621517)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605584646001) (:text |r0)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605585387427) (:text |1.6)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605584657493)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605584665386) (:text |r1)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605585266024)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605585266220) (:text |/)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605585353028) (:text |1.48)
+                              |r $ {} (:type :leaf) (:by |u0) (:at 1605585277853) (:text |3)
+                      |D $ {} (:type :expr) (:by |u0) (:at 1605584716340)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605584718941) (:text |b0)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605584768421) (:text |20)
+          |comp-todo-task $ {} (:type :expr) (:by |u0) (:at 1605609031986)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605609031986) (:text |def)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605609031986) (:text |comp-todo-task)
+              |r $ {} (:type :expr) (:by |u0) (:at 1605609031986)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609042308) (:text |{})
+                  |j $ {} (:type :expr) (:by |u0) (:at 1605609043303)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609044215) (:text |:type)
+                      |j $ {} (:type :leaf) (:by |u0) (:at 1605609947872) (:text |:comp)
+                  |r $ {} (:type :expr) (:by |u0) (:at 1605609049191)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609050527) (:text |:args)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605609050778)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609050924) (:text |[])
+                  |v $ {} (:type :expr) (:by |u0) (:at 1605609051800)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609054844) (:text |:render)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605609055113)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609056412) (:text |fn)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605609056694)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609058125) (:text |cursor)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605609058740) (:text |state)
+                          |r $ {} (:type :expr) (:by |u0) (:at 1605609059386)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609060389) (:text |fn)
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605609060757)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609062191) (:text |args)
+                                  |D $ {} (:type :leaf) (:by |u0) (:at 1605609968000) (:text |&)
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605609063474)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609063790) (:text |{})
+                                  |j $ {} (:type :expr) (:by |u0) (:at 1605609064026)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609066212) (:text |:children)
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605609068255)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609070214) (:text |{})
+                                  |r $ {} (:type :expr) (:by |u0) (:at 1605609071348)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609073950) (:text |:render)
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605609074233)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609075593) (:text |fn)
+                                          |j $ {} (:type :expr) (:by |u0) (:at 1605609075871)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609077925) (:text |dict)
+                                          |r $ {} (:type :expr) (:by |u0) (:at 1605609078996)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609079376) (:text |{})
+                                              |j $ {} (:type :expr) (:by |u0) (:at 1605609079893)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609081494) (:text |:type)
+                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605609084151) (:text |:group)
+                                              |r $ {} (:type :expr) (:by |u0) (:at 1605609084761)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609087386) (:text |:children)
+                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605609088035)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609088225) (:text |[])
+                  |x $ {} (:type :expr) (:by |u0) (:at 1605609090447)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609092392) (:text |:events)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605609093168)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609093952) (:text |{})
+          |on-window-event $ {} (:type :expr) (:by |u0) (:at 1605514426898)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605514426898) (:text |defn)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605515054374) (:text |on-window-event)
+              |r $ {} (:type :expr) (:by |u0) (:at 1605514426898)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605514430293) (:text |event)
+              |v $ {} (:type :expr) (:by |u0) (:at 1605514430703)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605514431159) (:text |echo)
+                  |j $ {} (:type :leaf) (:by |u0) (:at 1605514431832) (:text |event)
+          |*app-states $ {} (:type :expr) (:by |u0) (:at 1605607758411)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605607760929) (:text |defatom)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605607758411) (:text |*app-states)
+              |r $ {} (:type :expr) (:by |u0) (:at 1605607758411)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605607763074) (:text |{})
+          |render-shape $ {} (:type :expr) (:by |u0) (:at 1605584374701)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605584374701) (:text |defn)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605584374701) (:text |render-shape)
+              |r $ {} (:type :expr) (:by |u0) (:at 1605584374701) (:data $ {})
+              |v $ {} (:type :expr) (:by |u0) (:at 1605584447594)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605584394173) (:text |;)
+                  |j $ {} (:type :leaf) (:by |u0) (:at 1605584381253) (:text |render-cycloid)
+              |x $ {} (:type :expr) (:by |u0) (:at 1605584408427)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605584417486) (:text |render-rotate)
+              |w $ {} (:type :expr) (:by |u0) (:at 1605608878583)
+                :data $ {}
+                  |T $ {} (:type :expr) (:by |u0) (:at 1605608886883)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |u0) (:at 1605607710368)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605607715052) (:text |expand-tree)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605607766890)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605607757676) (:text |*app-states)
+                              |D $ {} (:type :leaf) (:by |u0) (:at 1605607768774) (:text |deref)
+                          |b $ {} (:type :expr) (:by |u0) (:at 1605607791307)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605607793219) (:text |merge)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605607802629) (:text |comp-todo-list)
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605607804169)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605607805038) (:text |{})
+                                  |j $ {} (:type :expr) (:by |u0) (:at 1605607805720)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605607806505) (:text |:args)
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605607807299)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605607807130) (:text |[])
+                          |f $ {} (:type :expr) (:by |u0) (:at 1605607787081)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605607787331) (:text |[])
+                      |D $ {} (:type :leaf) (:by |u0) (:at 1605608888090) (:text |tree)
+                  |D $ {} (:type :leaf) (:by |u0) (:at 1605608882131) (:text |&let)
+                  |j $ {} (:type :expr) (:by |u0) (:at 1605608889991)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608894244) (:text |reset!)
+                      |j $ {} (:type :leaf) (:by |u0) (:at 1605608901640) (:text |*app-states)
+                      |r $ {} (:type :leaf) (:by |u0) (:at 1605608903716) (:text |tree)
+                  |r $ {} (:type :expr) (:by |u0) (:at 1605608932257)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608904866) (:text |tree)
+                      |D $ {} (:type :leaf) (:by |u0) (:at 1605608934996) (:text |echo)
+                      |L $ {} (:type :leaf) (:by |u0) (:at 1605609368691) (:text "|\"tree:")
+                  |v $ {} (:type :expr) (:by |u0) (:at 1605608936073)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608936573) (:text |echo)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605608938339)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608941313) (:text |get-shape-tree)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605608944307) (:text |tree)
+                      |b $ {} (:type :leaf) (:by |u0) (:at 1605609372343) (:text "|\"shape:")
           |reload! $ {} (:type :expr) (:by |u0) (:at 1605513329498)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1605513329498) (:text |defn)
@@ -71,17 +526,16 @@
               |x $ {} (:type :expr) (:by |u0) (:at 1605513552484)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |u0) (:at 1605513554019) (:text |render-shape)
-          |render-shape $ {} (:type :expr) (:by |u0) (:at 1605513487978)
+          |render-cycloid $ {} (:type :expr) (:by |u0) (:at 1605513487978)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1605513487978) (:text |defn)
-              |j $ {} (:type :leaf) (:by |u0) (:at 1605513487978) (:text |render-shape)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605584359995) (:text |render-cycloid)
               |r $ {} (:type :expr) (:by |u0) (:at 1605513487978) (:data $ {})
               |v $ {} (:type :expr) (:by |u0) (:at 1605516691269)
                 :data $ {}
-                  |T $ {} (:type :expr) (:by |u0) (:at 1605514368960)
+                  |T $ {} (:type :expr) (:by |u0) (:at 1605584458768)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605514387494) (:text |draw-canvas)
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605515973340)
+                      |T $ {} (:type :expr) (:by |u0) (:at 1605515973340)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |u0) (:at 1605515973340) (:text |g)
                           |j $ {} (:type :expr) (:by |u0) (:at 1605515973340)
@@ -170,7 +624,7 @@
                                   |j $ {} (:type :expr) (:by |u0) (:at 1605515973340)
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:by |u0) (:at 1605515973340) (:text |[])
-                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605523733165) (:text |0)
+                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605584127147) (:text |0)
                                       |r $ {} (:type :leaf) (:by |u0) (:at 1605517038115) (:text |80)
                                       |v $ {} (:type :leaf) (:by |u0) (:at 1605517092035) (:text |60)
                               |y $ {} (:type :expr) (:by |u0) (:at 1605515973340)
@@ -185,6 +639,7 @@
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |u0) (:at 1605524322778) (:text |:skip-first?)
                                   |j $ {} (:type :leaf) (:by |u0) (:at 1605524324162) (:text |true)
+                      |D $ {} (:type :leaf) (:by |u0) (:at 1605584459532) (:text |draw-canvas)
                   |D $ {} (:type :leaf) (:by |u0) (:at 1605516692398) (:text |let)
                   |L $ {} (:type :expr) (:by |u0) (:at 1605516696462)
                     :data $ {}
@@ -228,17 +683,6 @@
                               |T $ {} (:type :leaf) (:by |u0) (:at 1605546624169) (:text |/)
                               |j $ {} (:type :leaf) (:by |u0) (:at 1605546625640) (:text |radius)
                               |r $ {} (:type :leaf) (:by |u0) (:at 1605546627103) (:text |t1)
-          |on-window-event $ {} (:type :expr) (:by |u0) (:at 1605514426898)
-            :data $ {}
-              |T $ {} (:type :leaf) (:by |u0) (:at 1605514426898) (:text |defn)
-              |j $ {} (:type :leaf) (:by |u0) (:at 1605515054374) (:text |on-window-event)
-              |r $ {} (:type :expr) (:by |u0) (:at 1605514426898)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:by |u0) (:at 1605514430293) (:text |event)
-              |v $ {} (:type :expr) (:by |u0) (:at 1605514430703)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:by |u0) (:at 1605514431159) (:text |echo)
-                  |j $ {} (:type :leaf) (:by |u0) (:at 1605514431832) (:text |event)
         :proc $ {} (:type :expr) (:by |u0) (:at 1605513209818) (:data $ {})
         :configs $ {}
       |phlox.core $ {}
@@ -247,6 +691,310 @@
             |T $ {} (:type :leaf) (:by |u0) (:at 1605513215399) (:text |ns)
             |j $ {} (:type :leaf) (:by |u0) (:at 1605513215399) (:text |phlox.core)
         :defs $ {}
+          |expand-tree $ {} (:type :expr) (:by |u0) (:at 1605597943340)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605597943340) (:text |defn)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605597943340) (:text |expand-tree)
+              |r $ {} (:type :expr) (:by |u0) (:at 1605597943340)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605604893264) (:text |tree)
+                  |j $ {} (:type :leaf) (:by |u0) (:at 1605604897286) (:text |coord)
+                  |r $ {} (:type :leaf) (:by |u0) (:at 1605605937234) (:text |states)
+              |v $ {} (:type :expr) (:by |u0) (:at 1605604898929)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605605072834) (:text |case)
+                  |j $ {} (:type :expr) (:by |u0) (:at 1605604901205)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605604902545) (:text |:type)
+                      |j $ {} (:type :leaf) (:by |u0) (:at 1605604917838) (:text |tree)
+                  |r $ {} (:type :expr) (:by |u0) (:at 1605604919110)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609935542) (:text |:comp)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605605944413)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605607899683) (:text |&let)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605605949730)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605605950582) (:text |renderer)
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605605951289)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605605953361) (:text |:render)
+                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605605959081) (:text |tree)
+                          |r $ {} (:type :expr) (:by |u0) (:at 1605605960683)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605605963467) (:text |assert)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605605974160) (:text "|\"render function for component")
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605605975302)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605605976232) (:text |fn?)
+                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605605981246) (:text |renderer)
+                          |v $ {} (:type :expr) (:by |u0) (:at 1605608176502)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |u0) (:at 1605606086150)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605606086150) (:text |{})
+                                  |j $ {} (:type :expr) (:by |u0) (:at 1605606086150)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605606086150) (:text |:type)
+                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605610077543) (:text |:component)
+                                  |r $ {} (:type :expr) (:by |u0) (:at 1605606087995)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605606092988) (:text |:events)
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605606093508)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605606095169) (:text |:events)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605606096197) (:text |tree)
+                                  |n $ {} (:type :expr) (:by |u0) (:at 1605608217836)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608219676) (:text |:children)
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605608220687)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608221783) (:text |:children)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605608223409) (:text |internal-result)
+                                  |p $ {} (:type :expr) (:by |u0) (:at 1605608224669)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608226833) (:text |:tree)
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605608227495)
+                                        :data $ {}
+                                          |j $ {} (:type :expr) (:by |u0) (:at 1605608230505)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608236139) (:text |:render)
+                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605608246308) (:text |internal-result)
+                                          |L $ {} (:type :leaf) (:by |u0) (:at 1605608264239) (:text |apply)
+                                          |r $ {} (:type :expr) (:by |u0) (:at 1605609777634)
+                                            :data $ {}
+                                              |T $ {} (:type :expr) (:by |u0) (:at 1605608273974)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608270926) (:text |:children)
+                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605608276257) (:text |internal-result)
+                                              |D $ {} (:type :leaf) (:by |u0) (:at 1605609778180) (:text |[])
+                              |D $ {} (:type :leaf) (:by |u0) (:at 1605608177981) (:text |&let)
+                              |L $ {} (:type :expr) (:by |u0) (:at 1605608178904)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608207649) (:text |internal-result)
+                                  |j $ {} (:type :expr) (:by |u0) (:at 1605608213363)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |apply)
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605608213363)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |renderer)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |coord)
+                                          |r $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |states)
+                                      |r $ {} (:type :expr) (:by |u0) (:at 1605608213363)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |:args)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |tree)
+                  |v $ {} (:type :expr) (:by |u0) (:at 1605605077577)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605605078524) (:text |:group)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605605137296)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605605139229) (:text |update)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605605140454) (:text |tree)
+                          |r $ {} (:type :leaf) (:by |u0) (:at 1605605142384) (:text |:children)
+                          |v $ {} (:type :expr) (:by |u0) (:at 1605608027431)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605605142826) (:text |fn)
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605605143074)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605605145213) (:text |xs)
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605605569197)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605605569957) (:text |map)
+                                  |j $ {} (:type :expr) (:by |u0) (:at 1605605573977)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605605574785) (:text |fn)
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605605575144)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605605575369) (:text |x)
+                                      |r $ {} (:type :expr) (:by |u0) (:at 1605605575791)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605605578703) (:text |expand-tree)
+                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605605580481) (:text |x)
+                                          |r $ {} (:type :leaf) (:by |u0) (:at 1605605582954) (:text |coord)
+                                  |r $ {} (:type :leaf) (:by |u0) (:at 1605605586240) (:text |xs)
+                  |x $ {} (:type :expr) (:by |u0) (:at 1605605079234)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |u0) (:at 1605605081678)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605605082184) (:text |:type)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605605084026) (:text |tree)
+                      |j $ {} (:type :leaf) (:by |u0) (:at 1605605111125) (:text |tree)
+          |wrap-keywords-in-path $ {} (:type :expr) (:by |u0) (:at 1605603183115)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605603183115) (:text |defn)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605603183115) (:text |wrap-keywords-in-path)
+              |r $ {} (:type :expr) (:by |u0) (:at 1605603183115)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605604449348) (:text |xs0)
+              |v $ {} (:type :expr) (:by |u0) (:at 1605603391312)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605603393369) (:text |apply)
+                  |j $ {} (:type :expr) (:by |u0) (:at 1605603393646)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605603394808) (:text |fn)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605603395125)
+                        :data $ {}
+                          |D $ {} (:type :leaf) (:by |u0) (:at 1605604451392) (:text |xs)
+                          |5 $ {} (:type :leaf) (:by |u0) (:at 1605604457419) (:text |acc)
+                      |r $ {} (:type :expr) (:by |u0) (:at 1605604458205)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605604458668) (:text |if)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605604459015)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605604460273) (:text |empty?)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605604461749) (:text |xs)
+                          |r $ {} (:type :leaf) (:by |u0) (:at 1605604463879) (:text |acc)
+                          |v $ {} (:type :expr) (:by |u0) (:at 1605604464556)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605604465725) (:text |recur)
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605604466016)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605604468821) (:text |append)
+                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605604476787) (:text |acc)
+                                  |r $ {} (:type :expr) (:by |u0) (:at 1605604591979)
+                                    :data $ {}
+                                      |T $ {} (:type :expr) (:by |u0) (:at 1605604484216)
+                                        :data $ {}
+                                          |D $ {} (:type :leaf) (:by |u0) (:at 1605604484809) (:text |if)
+                                          |L $ {} (:type :expr) (:by |u0) (:at 1605604485620)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605604590301) (:text |keyword?)
+                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605604604977) (:text |x0)
+                                          |P $ {} (:type :expr) (:by |u0) (:at 1605604613309)
+                                            :data $ {}
+                                              |T $ {} (:type :expr) (:by |u0) (:at 1605604608658)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605604610388) (:text |turn-str)
+                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605604611394) (:text |x0)
+                                              |D $ {} (:type :leaf) (:by |u0) (:at 1605604616937) (:text |str)
+                                              |L $ {} (:type :leaf) (:by |u0) (:at 1605604619195) (:text "|\":")
+                                          |h $ {} (:type :expr) (:by |u0) (:at 1605604625969)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605604628241) (:text |turn-str)
+                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605604631464) (:text |x0)
+                                      |D $ {} (:type :leaf) (:by |u0) (:at 1605604595128) (:text |let&)
+                                      |L $ {} (:type :expr) (:by |u0) (:at 1605604595603)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605604596348) (:text |x0)
+                                          |j $ {} (:type :expr) (:by |u0) (:at 1605604597915)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605604600069) (:text |first)
+                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605604600422) (:text |xs)
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605604478794)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605604479324) (:text |rest)
+                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605604479794) (:text |xs)
+                  |r $ {} (:type :expr) (:by |u0) (:at 1605603397898)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605603405110) (:text |[])
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605604432919)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605604433428) (:text |[])
+                      |r $ {} (:type :leaf) (:by |u0) (:at 1605604447628) (:text |xs0)
+          |handle-tree-event $ {} (:type :expr) (:by |u0) (:at 1605598323672)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605598323672) (:text |defn)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605604731439) (:text |handle-tree-event)
+              |r $ {} (:type :expr) (:by |u0) (:at 1605598323672) (:data $ {})
+          |*tree-state $ {} (:type :expr) (:by |u0) (:at 1605597974750)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605597979250) (:text |defatom)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605604861087) (:text |*tree-state)
+              |r $ {} (:type :leaf) (:by |u0) (:at 1605597991156) (:text |nil)
+          |get-shape-tree $ {} (:type :expr) (:by |u0) (:at 1605597959027)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605597959027) (:text |defn)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605606244676) (:text |get-shape-tree)
+              |r $ {} (:type :expr) (:by |u0) (:at 1605597959027)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605606200776) (:text |tree)
+              |v $ {} (:type :expr) (:by |u0) (:at 1605606202045)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605606202559) (:text |case)
+                  |j $ {} (:type :expr) (:by |u0) (:at 1605606204948)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605606204045) (:text |tree)
+                      |D $ {} (:type :leaf) (:by |u0) (:at 1605606208172) (:text |:type)
+                  |r $ {} (:type :expr) (:by |u0) (:at 1605606208954)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605606211032) (:text |:component)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605609828332)
+                        :data $ {}
+                          |T $ {} (:type :expr) (:by |u0) (:at 1605606304803)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605606305611) (:text |:tree)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605606307301) (:text |tree)
+                          |D $ {} (:type :leaf) (:by |u0) (:at 1605609831454) (:text |get-shape-tree)
+                  |n $ {} (:type :expr) (:by |u0) (:at 1605606213641)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605606214792) (:text |:group)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605606223561)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605606224276) (:text |update)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605606226487) (:text |tree)
+                          |r $ {} (:type :leaf) (:by |u0) (:at 1605606229875) (:text |:children)
+                          |v $ {} (:type :expr) (:by |u0) (:at 1605606230344)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605606230648) (:text |fn)
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605606230939)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605606232106) (:text |xs)
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605606250474)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605606255773) (:text |map)
+                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605606258992) (:text |get-shape-tree)
+                                  |r $ {} (:type :leaf) (:by |u0) (:at 1605606261748) (:text |xs)
+                  |v $ {} (:type :expr) (:by |u0) (:at 1605606219972)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |u0) (:at 1605606216328)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605606217980) (:text |:type)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605606219475) (:text |tree)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605606365573)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605606221652) (:text |tree)
+                          |D $ {} (:type :leaf) (:by |u0) (:at 1605606367404) (:text |update)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605606369244) (:text |:path)
+                          |r $ {} (:type :expr) (:by |u0) (:at 1605606369855)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605606370134) (:text |fn)
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605606370411)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605606371272) (:text |path)
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605606372002)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605606372388) (:text |if)
+                                  |j $ {} (:type :expr) (:by |u0) (:at 1605606373249)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605606373500) (:text |nil?)
+                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605606374135) (:text |path)
+                                  |r $ {} (:type :leaf) (:by |u0) (:at 1605606375640) (:text |path)
+                                  |v $ {} (:type :expr) (:by |u0) (:at 1605606376583)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605606397766) (:text |wrap-keywords-in-path)
+                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605606399791) (:text |path)
+                  |l $ {} (:type :expr) (:by |u0) (:at 1605609841389)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609841114) (:text |nil)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605609857123)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609857934) (:text |nil)
+                          |D $ {} (:type :leaf) (:by |u0) (:at 1605609858482) (:text |do)
+                          |L $ {} (:type :expr) (:by |u0) (:at 1605609858991)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609860705) (:text |echo)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605609869244) (:text "|\"nil type from tree:")
+                              |r $ {} (:type :leaf) (:by |u0) (:at 1605609870527) (:text |tree)
+          |def $ {} (:type :expr) (:by |u0) (:at 1605608517690)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605608521966) (:text |defmacro)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605608517690) (:text |def)
+              |r $ {} (:type :expr) (:by |u0) (:at 1605608517690)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608532568) (:text |name)
+                  |j $ {} (:type :leaf) (:by |u0) (:at 1605608533713) (:text |x)
+              |v $ {} (:type :leaf) (:by |u0) (:at 1605608534423) (:text |x)
         :proc $ {} (:type :expr) (:by |u0) (:at 1605513215399) (:data $ {})
         :configs $ {}
       |phlox.complex $ {}
@@ -265,7 +1013,7 @@
                   |j $ {} (:type :leaf) (:by |u0) (:at 1605546107095) (:text |p2)
               |v $ {} (:type :expr) (:by |u0) (:at 1605546107585)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:by |u0) (:at 1605546223579) (:text |&[])
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605604318555) (:text |[])
                   |j $ {} (:type :expr) (:by |u0) (:at 1605546108935)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |u0) (:at 1605546225997) (:text |&+)
@@ -298,7 +1046,7 @@
                   |j $ {} (:type :leaf) (:by |u0) (:at 1605546140592) (:text |p2)
               |v $ {} (:type :expr) (:by |u0) (:at 1605546140592)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:by |u0) (:at 1605546219839) (:text |&[])
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605604322617) (:text |[])
                   |j $ {} (:type :expr) (:by |u0) (:at 1605546140592)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |u0) (:at 1605546215840) (:text |&-)
@@ -327,7 +1075,7 @@
               |j $ {} (:type :leaf) (:by |u0) (:at 1605546154281) (:text |c*)
               |r $ {} (:type :expr) (:by |u0) (:at 1605546158478)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:by |u0) (:at 1605546231325) (:text |&[])
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605604343874) (:text |[])
                   |j $ {} (:type :expr) (:by |u0) (:at 1605546173003)
                     :data $ {}
                       |T $ {} (:type :expr) (:by |u0) (:at 1605546158478)
@@ -391,7 +1139,7 @@
                   |T $ {} (:type :leaf) (:by |u0) (:at 1605547624191) (:text |x)
               |v $ {} (:type :expr) (:by |u0) (:at 1605547625296)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:by |u0) (:at 1605547632322) (:text |&[])
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605604327690) (:text |[])
                   |j $ {} (:type :expr) (:by |u0) (:at 1605547625296)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |u0) (:at 1605547625296) (:text |cos)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -33,187 +33,9 @@
                       :data $ {}
                         |T $ {} (:type :leaf) (:by |u0) (:at 1605607728938) (:text |[])
                         |j $ {} (:type :leaf) (:by |u0) (:at 1605607737932) (:text |expand-tree)
-                        |r $ {} (:type :leaf) (:by |u0) (:at 1605608551175) (:text |def)
                         |v $ {} (:type :leaf) (:by |u0) (:at 1605608929110) (:text |get-shape-tree)
                         |x $ {} (:type :leaf) (:by |u0) (:at 1605672962462) (:text |g)
         :defs $ {}
-          |comp-todo-list $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-            :data $ {}
-              |T $ {} (:type :leaf) (:by |u0) (:at 1605608555351) (:text |def)
-              |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
-                  |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:type)
-                      |j $ {} (:type :leaf) (:by |u0) (:at 1605609941383) (:text |:comp)
-                  |r $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:s0)
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
-                  |v $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:args)
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |[])
-                  |x $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:render)
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |fn)
-                          |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |cursor)
-                              |j $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |state)
-                          |r $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |fn)
-                              |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |&)
-                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |args)
-                              |r $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
-                                  |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:children)
-                                      |j $ {} (:type :expr) (:by |u0) (:at 1605609174711)
-                                        :data $ {}
-                                          |T $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
-                                              |j $ {} (:type :expr) (:by |u0) (:at 1605609164723)
-                                                :data $ {}
-                                                  |T $ {} (:type :expr) (:by |u0) (:at 1605609025517)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609026887) (:text |merge)
-                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605609030641) (:text |comp-todo-task)
-                                                      |r $ {} (:type :expr) (:by |u0) (:at 1605609185819)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609186991) (:text |{})
-                                                          |j $ {} (:type :expr) (:by |u0) (:at 1605609187389)
-                                                            :data $ {}
-                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609188635) (:text |:args)
-                                                              |j $ {} (:type :expr) (:by |u0) (:at 1605609189493)
-                                                                :data $ {}
-                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609189733) (:text |[])
-                                                  |D $ {} (:type :leaf) (:by |u0) (:at 1605609172313) (:text |:header)
-                                          |D $ {} (:type :leaf) (:by |u0) (:at 1605609175555) (:text |merge)
-                                          |j $ {} (:type :expr) (:by |u0) (:at 1605609197609)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609199195) (:text |->>)
-                                              |j $ {} (:type :expr) (:by |u0) (:at 1605609200504)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609199905) (:text |range)
-                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605609203617) (:text |3)
-                                              |r $ {} (:type :expr) (:by |u0) (:at 1605609205143)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609206240) (:text |map)
-                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605609206681)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609207339) (:text |fn)
-                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605609207656)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609208103) (:text |x)
-                                                      |r $ {} (:type :expr) (:by |u0) (:at 1605609231215)
-                                                        :data $ {}
-                                                          |T $ {} (:type :expr) (:by |u0) (:at 1605609210680)
-                                                            :data $ {}
-                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609221505) (:text |merge)
-                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605609223897) (:text |comp-todo-task)
-                                                              |r $ {} (:type :expr) (:by |u0) (:at 1605609224892)
-                                                                :data $ {}
-                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609225219) (:text |{})
-                                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605609225524)
-                                                                    :data $ {}
-                                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609226164) (:text |:args)
-                                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605609226858)
-                                                                        :data $ {}
-                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609226651) (:text |[])
-                                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605609228218) (:text |x)
-                                                          |D $ {} (:type :leaf) (:by |u0) (:at 1605609232440) (:text |[])
-                                                          |L $ {} (:type :expr) (:by |u0) (:at 1605609233194)
-                                                            :data $ {}
-                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609233662) (:text |str)
-                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605609237601) (:text ||task-)
-                                                              |r $ {} (:type :leaf) (:by |u0) (:at 1605609238193) (:text |x)
-                                              |v $ {} (:type :expr) (:by |u0) (:at 1605609241009)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605669668331) (:text |pairs-map)
-                                  |r $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608634793) (:text |:render)
-                                      |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |fn)
-                                          |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |dict)
-                                          |r $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
-                                              |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:type)
-                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:group)
-                                              |r $ {} (:type :expr) (:by |u0) (:at 1605608967860)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608970172) (:text |:children)
-                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605608971265)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608971542) (:text |[])
-                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605609279465)
-                                                        :data $ {}
-                                                          |T $ {} (:type :expr) (:by |u0) (:at 1605609269716)
-                                                            :data $ {}
-                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609278188) (:text |:group)
-                                                              |D $ {} (:type :leaf) (:by |u0) (:at 1605609281909) (:text |:type)
-                                                          |D $ {} (:type :leaf) (:by |u0) (:at 1605609279980) (:text |{})
-                                                          |j $ {} (:type :expr) (:by |u0) (:at 1605609282628)
-                                                            :data $ {}
-                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609302591) (:text |:children)
-                                                              |j $ {} (:type :expr) (:by |u0) (:at 1605609308104)
-                                                                :data $ {}
-                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609314395) (:text |->>)
-                                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605609312316)
-                                                                    :data $ {}
-                                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609311200) (:text |range)
-                                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605609313297) (:text |3)
-                                                                  |r $ {} (:type :expr) (:by |u0) (:at 1605609316099)
-                                                                    :data $ {}
-                                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609324994) (:text |map)
-                                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605609326328)
-                                                                        :data $ {}
-                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609326574) (:text |fn)
-                                                                          |j $ {} (:type :expr) (:by |u0) (:at 1605609327247)
-                                                                            :data $ {}
-                                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609326893) (:text |x)
-                                                                          |r $ {} (:type :expr) (:by |u0) (:at 1605609330071)
-                                                                            :data $ {}
-                                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609335565) (:text |get)
-                                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605609336989) (:text |dict)
-                                                                              |r $ {} (:type :expr) (:by |u0) (:at 1605609339967)
-                                                                                :data $ {}
-                                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609339967) (:text |str)
-                                                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605609339967) (:text ||task-)
-                                                                                  |r $ {} (:type :leaf) (:by |u0) (:at 1605609339967) (:text |x)
-                                                      |b $ {} (:type :expr) (:by |u0) (:at 1605609290097)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609290854) (:text |get)
-                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605609292438) (:text |dict)
-                                                          |r $ {} (:type :leaf) (:by |u0) (:at 1605609295058) (:text |:header)
-                  |y $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:events)
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
-              |b $ {} (:type :leaf) (:by |u0) (:at 1605608578523) (:text |comp-todo-list)
           |main! $ {} (:type :expr) (:by |u0) (:at 1605513219471)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1605513219471) (:text |defn)
@@ -367,10 +189,10 @@
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |u0) (:at 1605584718941) (:text |b0)
                           |j $ {} (:type :leaf) (:by |u0) (:at 1605584768421) (:text |20)
-          |comp-todo-task $ {} (:type :expr) (:by |u0) (:at 1605609031986)
+          |comp-counter $ {} (:type :expr) (:by |u0) (:at 1605609031986)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1605609031986) (:text |def)
-              |j $ {} (:type :leaf) (:by |u0) (:at 1605609031986) (:text |comp-todo-task)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605674950050) (:text |comp-counter)
               |r $ {} (:type :expr) (:by |u0) (:at 1605609031986)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |u0) (:at 1605609042308) (:text |{})
@@ -399,8 +221,7 @@
                               |T $ {} (:type :leaf) (:by |u0) (:at 1605609060389) (:text |fn)
                               |j $ {} (:type :expr) (:by |u0) (:at 1605609060757)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609062191) (:text |args)
-                                  |D $ {} (:type :leaf) (:by |u0) (:at 1605609968000) (:text |&)
+                                  |D $ {} (:type :leaf) (:by |u0) (:at 1605694030830) (:text |c)
                               |r $ {} (:type :expr) (:by |u0) (:at 1605609063474)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |u0) (:at 1605609063790) (:text |{})
@@ -425,12 +246,167 @@
                                               |j $ {} (:type :expr) (:by |u0) (:at 1605674122964)
                                                 :data $ {}
                                                   |T $ {} (:type :leaf) (:by |u0) (:at 1605674123369) (:text |{})
+                                              |r $ {} (:type :expr) (:by |u0) (:at 1605694049201)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605694051095) (:text |{})
+                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605694051590)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694054737) (:text |:type)
+                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605694056496) (:text |:text)
+                                                  |r $ {} (:type :expr) (:by |u0) (:at 1605694057135)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694060822) (:text |:text)
+                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605694470676) (:text "|\"-")
+                                                  |v $ {} (:type :expr) (:by |u0) (:at 1605694070890)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694072374) (:text |:color)
+                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605694072594)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605694073033) (:text |[])
+                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605694073570) (:text |0)
+                                                          |r $ {} (:type :leaf) (:by |u0) (:at 1605694073778) (:text |0)
+                                                          |v $ {} (:type :leaf) (:by |u0) (:at 1605694075046) (:text |100)
+                                                  |x $ {} (:type :expr) (:by |u0) (:at 1605694080333)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694081174) (:text |:align)
+                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605695740668) (:text "|\"center")
+                                                  |n $ {} (:type :expr) (:by |u0) (:at 1605694090984)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694092311) (:text |:x)
+                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605694095302) (:text |0)
+                                              |v $ {} (:type :expr) (:by |u0) (:at 1605694049201)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605694051095) (:text |{})
+                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605694051590)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694054737) (:text |:type)
+                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605694056496) (:text |:text)
+                                                  |r $ {} (:type :expr) (:by |u0) (:at 1605694057135)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694060822) (:text |:text)
+                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605694062127)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605694063112) (:text |str)
+                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605694066391) (:text |c)
+                                                  |v $ {} (:type :expr) (:by |u0) (:at 1605694070890)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694072374) (:text |:color)
+                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605694072594)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605694073033) (:text |[])
+                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605694073570) (:text |0)
+                                                          |r $ {} (:type :leaf) (:by |u0) (:at 1605694073778) (:text |0)
+                                                          |v $ {} (:type :leaf) (:by |u0) (:at 1605694075046) (:text |100)
+                                                  |x $ {} (:type :expr) (:by |u0) (:at 1605694080333)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694081174) (:text |:align)
+                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605695737175) (:text "|\"center")
+                                                  |n $ {} (:type :expr) (:by |u0) (:at 1605694090984)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694092311) (:text |:x)
+                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605694100648) (:text |40)
+                                              |x $ {} (:type :expr) (:by |u0) (:at 1605694049201)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605694051095) (:text |{})
+                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605694051590)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694054737) (:text |:type)
+                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605694056496) (:text |:text)
+                                                  |r $ {} (:type :expr) (:by |u0) (:at 1605694057135)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694060822) (:text |:text)
+                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605694477777) (:text "|\"+")
+                                                  |v $ {} (:type :expr) (:by |u0) (:at 1605694070890)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694072374) (:text |:color)
+                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605694072594)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605694073033) (:text |[])
+                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605694073570) (:text |0)
+                                                          |r $ {} (:type :leaf) (:by |u0) (:at 1605695980668) (:text |90)
+                                                          |v $ {} (:type :leaf) (:by |u0) (:at 1605696384409) (:text |100)
+                                                  |x $ {} (:type :expr) (:by |u0) (:at 1605694080333)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694081174) (:text |:align)
+                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605696449657) (:text "|\"center")
+                                                  |n $ {} (:type :expr) (:by |u0) (:at 1605694090984)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694092311) (:text |:x)
+                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605696426478) (:text |80)
+                                              |n $ {} (:type :expr) (:by |u0) (:at 1605696397583)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605696398121) (:text |{})
+                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605696398595)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605696400483) (:text |:touch-area)
+                                                      |D $ {} (:type :leaf) (:by |u0) (:at 1605696402599) (:text |:type)
+                                                  |r $ {} (:type :expr) (:by |u0) (:at 1605696403185)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605696403898) (:text |:x)
+                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605696406761) (:text |0)
+                                                  |v $ {} (:type :expr) (:by |u0) (:at 1605696407332)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605696411657) (:text |:radius)
+                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605696429953) (:text |10)
+                                                  |x $ {} (:type :expr) (:by |u0) (:at 1605696413707)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605696415036) (:text |:path)
+                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605696415318)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605696415586) (:text |[])
+                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605696416933) (:text "|\"TODO")
+                                                  |y $ {} (:type :expr) (:by |u0) (:at 1605697071009)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605697072679) (:text |:events)
+                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605697073719)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605697073286) (:text |[])
+                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605697394750) (:text |:touch-down)
+                                              |p $ {} (:type :expr) (:by |u0) (:at 1605696397583)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605696398121) (:text |{})
+                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605696398595)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605696400483) (:text |:touch-area)
+                                                      |D $ {} (:type :leaf) (:by |u0) (:at 1605696402599) (:text |:type)
+                                                  |r $ {} (:type :expr) (:by |u0) (:at 1605696403185)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605696403898) (:text |:x)
+                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605696435306) (:text |80)
+                                                  |v $ {} (:type :expr) (:by |u0) (:at 1605696407332)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605696411657) (:text |:radius)
+                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605696431813) (:text |10)
+                                                  |x $ {} (:type :expr) (:by |u0) (:at 1605696413707)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605696415036) (:text |:path)
+                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605696415318)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605696415586) (:text |[])
+                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605697215411) (:text "|\"TODO")
+                                                  |y $ {} (:type :expr) (:by |u0) (:at 1605697085622)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605697085622) (:text |:events)
+                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605697085622)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605697085622) (:text |[])
+                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605697339113) (:text |:touch-down)
                   |x $ {} (:type :expr) (:by |u0) (:at 1605609090447)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |u0) (:at 1605609092392) (:text |:events)
                       |j $ {} (:type :expr) (:by |u0) (:at 1605609093168)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |u0) (:at 1605609093952) (:text |{})
+                  |n $ {} (:type :expr) (:by |u0) (:at 1605674955308)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605674957437) (:text |:s0)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605674959358)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605674959771) (:text |{})
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605674959992)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605674960715) (:text |:count)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605674962224) (:text |0)
           |on-window-event $ {} (:type :expr) (:by |u0) (:at 1605514426898)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1605514426898) (:text |defn)
@@ -449,6 +425,240 @@
               |r $ {} (:type :expr) (:by |u0) (:at 1605607758411)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |u0) (:at 1605607763074) (:text |{})
+          |comp-data-list $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605608555351) (:text |def)
+              |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
+                  |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:type)
+                      |j $ {} (:type :leaf) (:by |u0) (:at 1605609941383) (:text |:comp)
+                  |r $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:s0)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605696471686)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605696472310) (:text |:size)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605696472893) (:text |0)
+                  |v $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:args)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |[])
+                  |x $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:render)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |fn)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |cursor)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |state)
+                          |r $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |fn)
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605608381035) (:data $ {})
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
+                                  |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:children)
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605609197609)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609199195) (:text |->>)
+                                          |j $ {} (:type :expr) (:by |u0) (:at 1605609200504)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609199905) (:text |range)
+                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605609203617) (:text |3)
+                                          |r $ {} (:type :expr) (:by |u0) (:at 1605609205143)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609206240) (:text |map)
+                                              |j $ {} (:type :expr) (:by |u0) (:at 1605609206681)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609207339) (:text |fn)
+                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605609207656)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609208103) (:text |x)
+                                                  |r $ {} (:type :expr) (:by |u0) (:at 1605609231215)
+                                                    :data $ {}
+                                                      |T $ {} (:type :expr) (:by |u0) (:at 1605694421907)
+                                                        :data $ {}
+                                                          |T $ {} (:type :expr) (:by |u0) (:at 1605609210680)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609221505) (:text |merge)
+                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605674969743) (:text |comp-counter)
+                                                              |r $ {} (:type :expr) (:by |u0) (:at 1605609224892)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609225219) (:text |{})
+                                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605609225524)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609226164) (:text |:args)
+                                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605609226858)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609226651) (:text |[])
+                                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605609228218) (:text |x)
+                                                          |D $ {} (:type :leaf) (:by |u0) (:at 1605694423310) (:text |g)
+                                                          |L $ {} (:type :expr) (:by |u0) (:at 1605694423681)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605694424055) (:text |{})
+                                                              |j $ {} (:type :expr) (:by |u0) (:at 1605694425153)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605694425586) (:text |:x)
+                                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605694427037) (:text |0)
+                                                              |r $ {} (:type :expr) (:by |u0) (:at 1605694427490)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605694428408) (:text |:y)
+                                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605694428733)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605694429494) (:text |*)
+                                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605694432456) (:text |x)
+                                                                      |r $ {} (:type :leaf) (:by |u0) (:at 1605694442923) (:text |30)
+                                                      |D $ {} (:type :leaf) (:by |u0) (:at 1605609232440) (:text |[])
+                                                      |L $ {} (:type :expr) (:by |u0) (:at 1605609233194)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609233662) (:text |str)
+                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605609237601) (:text ||task-)
+                                                          |r $ {} (:type :leaf) (:by |u0) (:at 1605609238193) (:text |x)
+                                          |v $ {} (:type :expr) (:by |u0) (:at 1605609241009)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605669668331) (:text |pairs-map)
+                                  |r $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608634793) (:text |:render)
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |fn)
+                                          |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |dict)
+                                          |r $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
+                                              |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:type)
+                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:group)
+                                              |r $ {} (:type :expr) (:by |u0) (:at 1605608967860)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608970172) (:text |:children)
+                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605608971265)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608971542) (:text |[])
+                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605609279465)
+                                                        :data $ {}
+                                                          |T $ {} (:type :expr) (:by |u0) (:at 1605609269716)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609278188) (:text |:group)
+                                                              |D $ {} (:type :leaf) (:by |u0) (:at 1605609281909) (:text |:type)
+                                                          |D $ {} (:type :leaf) (:by |u0) (:at 1605609279980) (:text |{})
+                                                          |j $ {} (:type :expr) (:by |u0) (:at 1605609282628)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609302591) (:text |:children)
+                                                              |j $ {} (:type :expr) (:by |u0) (:at 1605694322665)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :expr) (:by |u0) (:at 1605696582047)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :expr) (:by |u0) (:at 1605609308104)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609314395) (:text |->>)
+                                                                          |j $ {} (:type :expr) (:by |u0) (:at 1605609312316)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609311200) (:text |range)
+                                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605609313297) (:text |3)
+                                                                          |r $ {} (:type :expr) (:by |u0) (:at 1605609316099)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609324994) (:text |map)
+                                                                              |j $ {} (:type :expr) (:by |u0) (:at 1605609326328)
+                                                                                :data $ {}
+                                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609326574) (:text |fn)
+                                                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605609327247)
+                                                                                    :data $ {}
+                                                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609326893) (:text |x)
+                                                                                  |r $ {} (:type :expr) (:by |u0) (:at 1605609330071)
+                                                                                    :data $ {}
+                                                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609335565) (:text |get)
+                                                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605609336989) (:text |dict)
+                                                                                      |r $ {} (:type :expr) (:by |u0) (:at 1605609339967)
+                                                                                        :data $ {}
+                                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609339967) (:text |str)
+                                                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605609339967) (:text ||task-)
+                                                                                          |r $ {} (:type :leaf) (:by |u0) (:at 1605609339967) (:text |x)
+                                                                      |D $ {} (:type :leaf) (:by |u0) (:at 1605696582603) (:text |g)
+                                                                      |L $ {} (:type :expr) (:by |u0) (:at 1605696583090)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605696583367) (:text |{})
+                                                                          |j $ {} (:type :expr) (:by |u0) (:at 1605696585704)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605696587557) (:text |:x)
+                                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605696588062) (:text |40)
+                                                                          |r $ {} (:type :expr) (:by |u0) (:at 1605696588555)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605696589386) (:text |:y)
+                                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605696682285) (:text |60)
+                                                                      |P $ {} (:type :leaf) (:by |u0) (:at 1605696613461) (:text |&)
+                                                                  |D $ {} (:type :leaf) (:by |u0) (:at 1605696622537) (:text |[])
+                                                                  |L $ {} (:type :expr) (:by |u0) (:at 1605696483359)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |{})
+                                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605696483359)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |:type)
+                                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |:text)
+                                                                      |r $ {} (:type :expr) (:by |u0) (:at 1605696483359)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |:x)
+                                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605696654957) (:text |20)
+                                                                      |v $ {} (:type :expr) (:by |u0) (:at 1605696483359)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |:text)
+                                                                          |j $ {} (:type :expr) (:by |u0) (:at 1605696543702)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :expr) (:by |u0) (:at 1605696483359)
+                                                                                :data $ {}
+                                                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605696507740) (:text |:size)
+                                                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605696518650) (:text |state)
+                                                                              |D $ {} (:type :leaf) (:by |u0) (:at 1605696544923) (:text |str)
+                                                                              |L $ {} (:type :leaf) (:by |u0) (:at 1605696576794) (:text "|\"Size: ")
+                                                                      |x $ {} (:type :expr) (:by |u0) (:at 1605696483359)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |:color)
+                                                                          |j $ {} (:type :expr) (:by |u0) (:at 1605696483359)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |[])
+                                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |0)
+                                                                              |r $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |0)
+                                                                              |v $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |100)
+                                                                      |y $ {} (:type :expr) (:by |u0) (:at 1605696483359)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text |:align)
+                                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605696483359) (:text "|\"center")
+                                                                      |t $ {} (:type :expr) (:by |u0) (:at 1605696528636)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605696529372) (:text |:y)
+                                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605696666622) (:text |20)
+                                              |n $ {} (:type :expr) (:by |u0) (:at 1605696595936)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605696597459) (:text |:x)
+                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605696676684) (:text |0)
+                                              |p $ {} (:type :expr) (:by |u0) (:at 1605696598834)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605696599385) (:text |:y)
+                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605696674465) (:text |0)
+                  |y $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |:events)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605608381035)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608381035) (:text |{})
+              |b $ {} (:type :leaf) (:by |u0) (:at 1605674978697) (:text |comp-data-list)
           |render-shape $ {} (:type :expr) (:by |u0) (:at 1605584374701)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1605584374701) (:text |defn)
@@ -458,9 +668,6 @@
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |u0) (:at 1605584394173) (:text |;)
                   |j $ {} (:type :leaf) (:by |u0) (:at 1605584381253) (:text |render-cycloid)
-              |x $ {} (:type :expr) (:by |u0) (:at 1605584408427)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:by |u0) (:at 1605584417486) (:text |render-rotate)
               |w $ {} (:type :expr) (:by |u0) (:at 1605608878583)
                 :data $ {}
                   |T $ {} (:type :expr) (:by |u0) (:at 1605608886883)
@@ -475,7 +682,7 @@
                           |b $ {} (:type :expr) (:by |u0) (:at 1605607791307)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |u0) (:at 1605607793219) (:text |merge)
-                              |j $ {} (:type :leaf) (:by |u0) (:at 1605607802629) (:text |comp-todo-list)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605674996697) (:text |comp-data-list)
                               |r $ {} (:type :expr) (:by |u0) (:at 1605607804169)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |u0) (:at 1605607805038) (:text |{})
@@ -499,21 +706,38 @@
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |u0) (:at 1605608904866) (:text |tree)
                       |D $ {} (:type :leaf) (:by |u0) (:at 1605608934996) (:text |echo)
-                  |v $ {} (:type :expr) (:by |u0) (:at 1605608936073)
+                      |5 $ {} (:type :leaf) (:by |u0) (:at 1605694190336) (:text |;)
+                  |v $ {} (:type :expr) (:by |u0) (:at 1605694200788)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608936573) (:text |echo)
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605608938339)
+                      |T $ {} (:type :expr) (:by |u0) (:at 1605608936073)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608941313) (:text |get-shape-tree)
-                          |j $ {} (:type :leaf) (:by |u0) (:at 1605608944307) (:text |tree)
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605694212543) (:text |info)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605608938339)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608941313) (:text |get-shape-tree)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605608944307) (:text |tree)
+                      |D $ {} (:type :leaf) (:by |u0) (:at 1605694203558) (:text |&let)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605694213805)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605694220907) (:text |draw-canvas)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605694221853) (:text |info)
+                      |b $ {} (:type :expr) (:by |u0) (:at 1605694224069)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605694224495) (:text |echo)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605694227215) (:text |info)
+                      |X $ {} (:type :expr) (:by |u0) (:at 1605694230524)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605694230524) (:text |echo)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605694230524) (:text "|\"shape:")
                   |n $ {} (:type :expr) (:by |u0) (:at 1605670243649)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |u0) (:at 1605670244183) (:text |echo)
                       |j $ {} (:type :leaf) (:by |u0) (:at 1605670247393) (:text "|\"tree:")
-                  |t $ {} (:type :expr) (:by |u0) (:at 1605670249911)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605670250666) (:text |echo)
-                      |j $ {} (:type :leaf) (:by |u0) (:at 1605670254358) (:text "|\"shape:")
+                      |D $ {} (:type :leaf) (:by |u0) (:at 1605694189811) (:text |;)
+              |vT $ {} (:type :expr) (:by |u0) (:at 1605694179060)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605694179060) (:text |render-rotate)
+                  |D $ {} (:type :leaf) (:by |u0) (:at 1605694179826) (:text |;)
           |reload! $ {} (:type :expr) (:by |u0) (:at 1605513329498)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1605513329498) (:text |defn)
@@ -691,6 +915,198 @@
             |T $ {} (:type :leaf) (:by |u0) (:at 1605513215399) (:text |ns)
             |j $ {} (:type :leaf) (:by |u0) (:at 1605513215399) (:text |phlox.core)
         :defs $ {}
+          |wrap-kwd-in-list $ {} (:type :expr) (:by |u0) (:at 1605695105039)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605695106489) (:text |defn)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605695105039) (:text |wrap-kwd-in-list)
+              |n $ {} (:type :expr) (:by |u0) (:at 1605695107822)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605695116401) (:text |xs0)
+              |p $ {} (:type :expr) (:by |u0) (:at 1605695213429)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605695213931) (:text |map)
+                  |j $ {} (:type :leaf) (:by |u0) (:at 1605695216534) (:text |wrap-keywords-in-path)
+                  |r $ {} (:type :leaf) (:by |u0) (:at 1605695217978) (:text |xs0)
+          |*tree-state $ {} (:type :expr) (:by |u0) (:at 1605597974750)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605597979250) (:text |defatom)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605604861087) (:text |*tree-state)
+              |r $ {} (:type :leaf) (:by |u0) (:at 1605597991156) (:text |nil)
+          |handle-tree-event $ {} (:type :expr) (:by |u0) (:at 1605598323672)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605598323672) (:text |defn)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605604731439) (:text |handle-tree-event)
+              |r $ {} (:type :expr) (:by |u0) (:at 1605598323672) (:data $ {})
+          |get-shape-tree $ {} (:type :expr) (:by |u0) (:at 1605597959027)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605597959027) (:text |defn)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605606244676) (:text |get-shape-tree)
+              |r $ {} (:type :expr) (:by |u0) (:at 1605597959027)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605606200776) (:text |tree)
+              |v $ {} (:type :expr) (:by |u0) (:at 1605606202045)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605606202559) (:text |case)
+                  |j $ {} (:type :expr) (:by |u0) (:at 1605606204948)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605606204045) (:text |tree)
+                      |D $ {} (:type :leaf) (:by |u0) (:at 1605606208172) (:text |:type)
+                  |r $ {} (:type :expr) (:by |u0) (:at 1605606208954)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605606211032) (:text |:component)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605609828332)
+                        :data $ {}
+                          |T $ {} (:type :expr) (:by |u0) (:at 1605606304803)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605606305611) (:text |:tree)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605606307301) (:text |tree)
+                          |D $ {} (:type :leaf) (:by |u0) (:at 1605609831454) (:text |get-shape-tree)
+                  |n $ {} (:type :expr) (:by |u0) (:at 1605606213641)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605606214792) (:text |:group)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605606223561)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605606224276) (:text |update)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605606226487) (:text |tree)
+                          |r $ {} (:type :leaf) (:by |u0) (:at 1605606229875) (:text |:children)
+                          |v $ {} (:type :expr) (:by |u0) (:at 1605606230344)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605606230648) (:text |fn)
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605606230939)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605606232106) (:text |xs)
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605606250474)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605606255773) (:text |map)
+                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605606258992) (:text |get-shape-tree)
+                                  |r $ {} (:type :leaf) (:by |u0) (:at 1605606261748) (:text |xs)
+                  |v $ {} (:type :expr) (:by |u0) (:at 1605606219972)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |u0) (:at 1605606216328)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605606217980) (:text |:type)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605606219475) (:text |tree)
+                      |j $ {} (:type :leaf) (:by |u0) (:at 1605671868132) (:text |tree)
+                  |l $ {} (:type :expr) (:by |u0) (:at 1605609841389)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609841114) (:text |nil)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605609857123)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609857934) (:text |nil)
+                          |D $ {} (:type :leaf) (:by |u0) (:at 1605609858482) (:text |do)
+                          |L $ {} (:type :expr) (:by |u0) (:at 1605609858991)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609860705) (:text |echo)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605609869244) (:text "|\"nil type from tree:")
+                              |r $ {} (:type :leaf) (:by |u0) (:at 1605609870527) (:text |tree)
+                  |t $ {} (:type :expr) (:by |u0) (:at 1605671858264)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605671860318) (:text |:touch-area)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605671865037)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |update)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |tree)
+                          |r $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |:path)
+                          |v $ {} (:type :expr) (:by |u0) (:at 1605671865037)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |fn)
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605671865037)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |path)
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605671865037)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |if)
+                                  |j $ {} (:type :expr) (:by |u0) (:at 1605671865037)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |nil?)
+                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |path)
+                                  |r $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |path)
+                                  |v $ {} (:type :expr) (:by |u0) (:at 1605671865037)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |wrap-keywords-in-path)
+                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |path)
+          |wrap-keywords-in-path $ {} (:type :expr) (:by |u0) (:at 1605603183115)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605603183115) (:text |defn)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605603183115) (:text |wrap-keywords-in-path)
+              |r $ {} (:type :expr) (:by |u0) (:at 1605603183115)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605695152463) (:text |x)
+              |v $ {} (:type :expr) (:by |u0) (:at 1605695143111)
+                :data $ {}
+                  |T $ {} (:type :expr) (:by |u0) (:at 1605695155778)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |u0) (:at 1605695111520)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605695105039) (:text |wrap-kwd-in-list)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605695153840) (:text |x)
+                      |D $ {} (:type :leaf) (:by |u0) (:at 1605695156706) (:text |:list)
+                  |D $ {} (:type :leaf) (:by |u0) (:at 1605695144979) (:text |case)
+                  |L $ {} (:type :expr) (:by |u0) (:at 1605695146276)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605695148252) (:text |type-of)
+                      |j $ {} (:type :leaf) (:by |u0) (:at 1605695150918) (:text |x)
+                  |j $ {} (:type :expr) (:by |u0) (:at 1605695157930)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605695159806) (:text |:map)
+                      |j $ {} (:type :leaf) (:by |u0) (:at 1605695160030) (:text |)
+                      |b $ {} (:type :expr) (:by |u0) (:at 1605695225982)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605695229662) (:text |wrap-kwd-in-map)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605695231067) (:text |x)
+                  |r $ {} (:type :expr) (:by |u0) (:at 1605695161452)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605695169771) (:text |:keyword)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605695179311)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605695179311) (:text |str)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605695179311) (:text "|\":")
+                          |r $ {} (:type :expr) (:by |u0) (:at 1605695179311)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605695179311) (:text |turn-str)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605695179311) (:text |x0)
+                  |v $ {} (:type :expr) (:by |u0) (:at 1605695282923)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |u0) (:at 1605695281392)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605695280381) (:text |type-of)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605695282061) (:text |x)
+                      |j $ {} (:type :leaf) (:by |u0) (:at 1605695284947) (:text |x)
+          |wrap-kwd-in-map $ {} (:type :expr) (:by |u0) (:at 1605695232281)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605695232281) (:text |defn)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605695232281) (:text |wrap-kwd-in-map)
+              |r $ {} (:type :expr) (:by |u0) (:at 1605695232281)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605695237335) (:text |xs)
+              |v $ {} (:type :expr) (:by |u0) (:at 1605695237795)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605695242291) (:text |->>)
+                  |j $ {} (:type :expr) (:by |u0) (:at 1605695242970)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605695244133) (:text |map-kv)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605695245022)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605695245343) (:text |fn)
+                          |j $ {} (:type :expr) (:by |u0) (:at 1605695245702)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605695247318) (:text |k)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605695248051) (:text |v)
+                          |r $ {} (:type :expr) (:by |u0) (:at 1605695252185)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605695252559) (:text |[])
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605695255522)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605695253620) (:text |k)
+                                  |D $ {} (:type :leaf) (:by |u0) (:at 1605695261344) (:text |wrap-keywords-in-path)
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605695263619)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605695253983) (:text |v)
+                                  |D $ {} (:type :leaf) (:by |u0) (:at 1605695266180) (:text |wrap-keywords-in-path)
+                  |b $ {} (:type :leaf) (:by |u0) (:at 1605695249628) (:text |xs)
+                  |r $ {} (:type :expr) (:by |u0) (:at 1605695268669)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605695270606) (:text |pairs-map)
           |expand-tree $ {} (:type :expr) (:by |u0) (:at 1605597943340)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1605597943340) (:text |defn)
@@ -868,185 +1284,6 @@
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |u0) (:at 1605668628393) (:text |:type)
                                   |j $ {} (:type :leaf) (:by |u0) (:at 1605668629009) (:text |tree)
-          |wrap-keywords-in-path $ {} (:type :expr) (:by |u0) (:at 1605603183115)
-            :data $ {}
-              |T $ {} (:type :leaf) (:by |u0) (:at 1605603183115) (:text |defn)
-              |j $ {} (:type :leaf) (:by |u0) (:at 1605603183115) (:text |wrap-keywords-in-path)
-              |r $ {} (:type :expr) (:by |u0) (:at 1605603183115)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:by |u0) (:at 1605604449348) (:text |xs0)
-              |v $ {} (:type :expr) (:by |u0) (:at 1605603391312)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:by |u0) (:at 1605603393369) (:text |apply)
-                  |j $ {} (:type :expr) (:by |u0) (:at 1605603393646)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605603394808) (:text |fn)
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605603395125)
-                        :data $ {}
-                          |D $ {} (:type :leaf) (:by |u0) (:at 1605604451392) (:text |xs)
-                          |5 $ {} (:type :leaf) (:by |u0) (:at 1605604457419) (:text |acc)
-                      |r $ {} (:type :expr) (:by |u0) (:at 1605604458205)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605604458668) (:text |if)
-                          |j $ {} (:type :expr) (:by |u0) (:at 1605604459015)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |u0) (:at 1605604460273) (:text |empty?)
-                              |j $ {} (:type :leaf) (:by |u0) (:at 1605604461749) (:text |xs)
-                          |r $ {} (:type :leaf) (:by |u0) (:at 1605604463879) (:text |acc)
-                          |v $ {} (:type :expr) (:by |u0) (:at 1605604464556)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |u0) (:at 1605604465725) (:text |recur)
-                              |j $ {} (:type :expr) (:by |u0) (:at 1605604466016)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605604468821) (:text |append)
-                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605604476787) (:text |acc)
-                                  |r $ {} (:type :expr) (:by |u0) (:at 1605604591979)
-                                    :data $ {}
-                                      |T $ {} (:type :expr) (:by |u0) (:at 1605604484216)
-                                        :data $ {}
-                                          |D $ {} (:type :leaf) (:by |u0) (:at 1605604484809) (:text |if)
-                                          |L $ {} (:type :expr) (:by |u0) (:at 1605604485620)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605604590301) (:text |keyword?)
-                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605604604977) (:text |x0)
-                                          |P $ {} (:type :expr) (:by |u0) (:at 1605604613309)
-                                            :data $ {}
-                                              |T $ {} (:type :expr) (:by |u0) (:at 1605604608658)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605604610388) (:text |turn-str)
-                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605604611394) (:text |x0)
-                                              |D $ {} (:type :leaf) (:by |u0) (:at 1605604616937) (:text |str)
-                                              |L $ {} (:type :leaf) (:by |u0) (:at 1605604619195) (:text "|\":")
-                                          |h $ {} (:type :expr) (:by |u0) (:at 1605604625969)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605604628241) (:text |turn-str)
-                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605604631464) (:text |x0)
-                                      |D $ {} (:type :leaf) (:by |u0) (:at 1605604595128) (:text |let&)
-                                      |L $ {} (:type :expr) (:by |u0) (:at 1605604595603)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605604596348) (:text |x0)
-                                          |j $ {} (:type :expr) (:by |u0) (:at 1605604597915)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605604600069) (:text |first)
-                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605604600422) (:text |xs)
-                              |r $ {} (:type :expr) (:by |u0) (:at 1605604478794)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605604479324) (:text |rest)
-                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605604479794) (:text |xs)
-                  |r $ {} (:type :expr) (:by |u0) (:at 1605603397898)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605603405110) (:text |[])
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605604432919)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605604433428) (:text |[])
-                      |r $ {} (:type :leaf) (:by |u0) (:at 1605604447628) (:text |xs0)
-          |handle-tree-event $ {} (:type :expr) (:by |u0) (:at 1605598323672)
-            :data $ {}
-              |T $ {} (:type :leaf) (:by |u0) (:at 1605598323672) (:text |defn)
-              |j $ {} (:type :leaf) (:by |u0) (:at 1605604731439) (:text |handle-tree-event)
-              |r $ {} (:type :expr) (:by |u0) (:at 1605598323672) (:data $ {})
-          |*tree-state $ {} (:type :expr) (:by |u0) (:at 1605597974750)
-            :data $ {}
-              |T $ {} (:type :leaf) (:by |u0) (:at 1605597979250) (:text |defatom)
-              |j $ {} (:type :leaf) (:by |u0) (:at 1605604861087) (:text |*tree-state)
-              |r $ {} (:type :leaf) (:by |u0) (:at 1605597991156) (:text |nil)
-          |get-shape-tree $ {} (:type :expr) (:by |u0) (:at 1605597959027)
-            :data $ {}
-              |T $ {} (:type :leaf) (:by |u0) (:at 1605597959027) (:text |defn)
-              |j $ {} (:type :leaf) (:by |u0) (:at 1605606244676) (:text |get-shape-tree)
-              |r $ {} (:type :expr) (:by |u0) (:at 1605597959027)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:by |u0) (:at 1605606200776) (:text |tree)
-              |v $ {} (:type :expr) (:by |u0) (:at 1605606202045)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:by |u0) (:at 1605606202559) (:text |case)
-                  |j $ {} (:type :expr) (:by |u0) (:at 1605606204948)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605606204045) (:text |tree)
-                      |D $ {} (:type :leaf) (:by |u0) (:at 1605606208172) (:text |:type)
-                  |r $ {} (:type :expr) (:by |u0) (:at 1605606208954)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605606211032) (:text |:component)
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605609828332)
-                        :data $ {}
-                          |T $ {} (:type :expr) (:by |u0) (:at 1605606304803)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |u0) (:at 1605606305611) (:text |:tree)
-                              |j $ {} (:type :leaf) (:by |u0) (:at 1605606307301) (:text |tree)
-                          |D $ {} (:type :leaf) (:by |u0) (:at 1605609831454) (:text |get-shape-tree)
-                  |n $ {} (:type :expr) (:by |u0) (:at 1605606213641)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605606214792) (:text |:group)
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605606223561)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605606224276) (:text |update)
-                          |j $ {} (:type :leaf) (:by |u0) (:at 1605606226487) (:text |tree)
-                          |r $ {} (:type :leaf) (:by |u0) (:at 1605606229875) (:text |:children)
-                          |v $ {} (:type :expr) (:by |u0) (:at 1605606230344)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |u0) (:at 1605606230648) (:text |fn)
-                              |j $ {} (:type :expr) (:by |u0) (:at 1605606230939)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605606232106) (:text |xs)
-                              |r $ {} (:type :expr) (:by |u0) (:at 1605606250474)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605606255773) (:text |map)
-                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605606258992) (:text |get-shape-tree)
-                                  |r $ {} (:type :leaf) (:by |u0) (:at 1605606261748) (:text |xs)
-                  |v $ {} (:type :expr) (:by |u0) (:at 1605606219972)
-                    :data $ {}
-                      |T $ {} (:type :expr) (:by |u0) (:at 1605606216328)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605606217980) (:text |:type)
-                          |j $ {} (:type :leaf) (:by |u0) (:at 1605606219475) (:text |tree)
-                      |j $ {} (:type :leaf) (:by |u0) (:at 1605671868132) (:text |tree)
-                  |l $ {} (:type :expr) (:by |u0) (:at 1605609841389)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609841114) (:text |nil)
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605609857123)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605609857934) (:text |nil)
-                          |D $ {} (:type :leaf) (:by |u0) (:at 1605609858482) (:text |do)
-                          |L $ {} (:type :expr) (:by |u0) (:at 1605609858991)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609860705) (:text |echo)
-                              |j $ {} (:type :leaf) (:by |u0) (:at 1605609869244) (:text "|\"nil type from tree:")
-                              |r $ {} (:type :leaf) (:by |u0) (:at 1605609870527) (:text |tree)
-                  |t $ {} (:type :expr) (:by |u0) (:at 1605671858264)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |u0) (:at 1605671860318) (:text |:touch-area)
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605671865037)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |update)
-                          |j $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |tree)
-                          |r $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |:path)
-                          |v $ {} (:type :expr) (:by |u0) (:at 1605671865037)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |fn)
-                              |j $ {} (:type :expr) (:by |u0) (:at 1605671865037)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |path)
-                              |r $ {} (:type :expr) (:by |u0) (:at 1605671865037)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |if)
-                                  |j $ {} (:type :expr) (:by |u0) (:at 1605671865037)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |nil?)
-                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |path)
-                                  |r $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |path)
-                                  |v $ {} (:type :expr) (:by |u0) (:at 1605671865037)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |wrap-keywords-in-path)
-                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |path)
-          |def $ {} (:type :expr) (:by |u0) (:at 1605608517690)
-            :data $ {}
-              |T $ {} (:type :leaf) (:by |u0) (:at 1605608521966) (:text |defmacro)
-              |j $ {} (:type :leaf) (:by |u0) (:at 1605608517690) (:text |def)
-              |r $ {} (:type :expr) (:by |u0) (:at 1605608517690)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608532568) (:text |name)
-                  |j $ {} (:type :leaf) (:by |u0) (:at 1605608533713) (:text |x)
-              |v $ {} (:type :leaf) (:by |u0) (:at 1605608534423) (:text |x)
           |g $ {} (:type :expr) (:by |u0) (:at 1605672941419)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1605672941419) (:text |defn)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -35,6 +35,7 @@
                         |j $ {} (:type :leaf) (:by |u0) (:at 1605607737932) (:text |expand-tree)
                         |r $ {} (:type :leaf) (:by |u0) (:at 1605608551175) (:text |def)
                         |v $ {} (:type :leaf) (:by |u0) (:at 1605608929110) (:text |get-shape-tree)
+                        |x $ {} (:type :leaf) (:by |u0) (:at 1605672962462) (:text |g)
         :defs $ {}
           |comp-todo-list $ {} (:type :expr) (:by |u0) (:at 1605608381035)
             :data $ {}
@@ -143,7 +144,7 @@
                                                               |r $ {} (:type :leaf) (:by |u0) (:at 1605609238193) (:text |x)
                                               |v $ {} (:type :expr) (:by |u0) (:at 1605609241009)
                                                 :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609257286) (:text |pair-map)
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605669668331) (:text |pairs-map)
                                   |r $ {} (:type :expr) (:by |u0) (:at 1605608381035)
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:by |u0) (:at 1605608634793) (:text |:render)
@@ -333,8 +334,8 @@
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |[])
                                       |j $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |0)
-                                      |r $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |80)
-                                      |v $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |60)
+                                      |r $ {} (:type :leaf) (:by |u0) (:at 1605670203531) (:text |30)
+                                      |v $ {} (:type :leaf) (:by |u0) (:at 1605670205049) (:text |30)
                               |y $ {} (:type :expr) (:by |u0) (:at 1605584475557)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |u0) (:at 1605584475557) (:text |:line-width)
@@ -418,19 +419,12 @@
                                           |j $ {} (:type :expr) (:by |u0) (:at 1605609075871)
                                             :data $ {}
                                               |T $ {} (:type :leaf) (:by |u0) (:at 1605609077925) (:text |dict)
-                                          |r $ {} (:type :expr) (:by |u0) (:at 1605609078996)
+                                          |v $ {} (:type :expr) (:by |u0) (:at 1605674121223)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605609079376) (:text |{})
-                                              |j $ {} (:type :expr) (:by |u0) (:at 1605609079893)
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605674121638) (:text |g)
+                                              |j $ {} (:type :expr) (:by |u0) (:at 1605674122964)
                                                 :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609081494) (:text |:type)
-                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605609084151) (:text |:group)
-                                              |r $ {} (:type :expr) (:by |u0) (:at 1605609084761)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605609087386) (:text |:children)
-                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605609088035)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605609088225) (:text |[])
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605674123369) (:text |{})
                   |x $ {} (:type :expr) (:by |u0) (:at 1605609090447)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |u0) (:at 1605609092392) (:text |:events)
@@ -505,7 +499,6 @@
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |u0) (:at 1605608904866) (:text |tree)
                       |D $ {} (:type :leaf) (:by |u0) (:at 1605608934996) (:text |echo)
-                      |L $ {} (:type :leaf) (:by |u0) (:at 1605609368691) (:text "|\"tree:")
                   |v $ {} (:type :expr) (:by |u0) (:at 1605608936073)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |u0) (:at 1605608936573) (:text |echo)
@@ -513,7 +506,14 @@
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |u0) (:at 1605608941313) (:text |get-shape-tree)
                           |j $ {} (:type :leaf) (:by |u0) (:at 1605608944307) (:text |tree)
-                      |b $ {} (:type :leaf) (:by |u0) (:at 1605609372343) (:text "|\"shape:")
+                  |n $ {} (:type :expr) (:by |u0) (:at 1605670243649)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605670244183) (:text |echo)
+                      |j $ {} (:type :leaf) (:by |u0) (:at 1605670247393) (:text "|\"tree:")
+                  |t $ {} (:type :expr) (:by |u0) (:at 1605670249911)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605670250666) (:text |echo)
+                      |j $ {} (:type :leaf) (:by |u0) (:at 1605670254358) (:text "|\"shape:")
           |reload! $ {} (:type :expr) (:by |u0) (:at 1605513329498)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1605513329498) (:text |defn)
@@ -747,10 +747,7 @@
                                   |n $ {} (:type :expr) (:by |u0) (:at 1605608217836)
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:by |u0) (:at 1605608219676) (:text |:children)
-                                      |j $ {} (:type :expr) (:by |u0) (:at 1605608220687)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608221783) (:text |:children)
-                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605608223409) (:text |internal-result)
+                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605671012683) (:text |children)
                                   |p $ {} (:type :expr) (:by |u0) (:at 1605608224669)
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:by |u0) (:at 1605608226833) (:text |:tree)
@@ -763,27 +760,66 @@
                                           |L $ {} (:type :leaf) (:by |u0) (:at 1605608264239) (:text |apply)
                                           |r $ {} (:type :expr) (:by |u0) (:at 1605609777634)
                                             :data $ {}
-                                              |T $ {} (:type :expr) (:by |u0) (:at 1605608273974)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608270926) (:text |:children)
-                                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605608276257) (:text |internal-result)
                                               |D $ {} (:type :leaf) (:by |u0) (:at 1605609778180) (:text |[])
-                              |D $ {} (:type :leaf) (:by |u0) (:at 1605608177981) (:text |&let)
-                              |L $ {} (:type :expr) (:by |u0) (:at 1605608178904)
+                                              |b $ {} (:type :leaf) (:by |u0) (:at 1605671017871) (:text |children)
+                              |D $ {} (:type :leaf) (:by |u0) (:at 1605671000850) (:text |let)
+                              |L $ {} (:type :expr) (:by |u0) (:at 1605671003408)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605608207649) (:text |internal-result)
-                                  |j $ {} (:type :expr) (:by |u0) (:at 1605608213363)
+                                  |T $ {} (:type :expr) (:by |u0) (:at 1605608178904)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |apply)
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605608207649) (:text |internal-result)
                                       |j $ {} (:type :expr) (:by |u0) (:at 1605608213363)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |renderer)
-                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |coord)
-                                          |r $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |states)
-                                      |r $ {} (:type :expr) (:by |u0) (:at 1605608213363)
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |apply)
+                                          |j $ {} (:type :expr) (:by |u0) (:at 1605608213363)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |renderer)
+                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |coord)
+                                              |r $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |states)
+                                          |r $ {} (:type :expr) (:by |u0) (:at 1605608213363)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |:args)
+                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |tree)
+                                  |j $ {} (:type :expr) (:by |u0) (:at 1605671004619)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605671006219) (:text |children)
+                                      |j $ {} (:type :expr) (:by |u0) (:at 1605671008950)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |:args)
-                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605608213363) (:text |tree)
+                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |->>)
+                                          |j $ {} (:type :expr) (:by |u0) (:at 1605671008950)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |:children)
+                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |internal-result)
+                                          |r $ {} (:type :expr) (:by |u0) (:at 1605671008950)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |map-kv)
+                                              |j $ {} (:type :expr) (:by |u0) (:at 1605671008950)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |fn)
+                                                  |j $ {} (:type :expr) (:by |u0) (:at 1605671008950)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |k)
+                                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |v)
+                                                  |r $ {} (:type :expr) (:by |u0) (:at 1605671008950)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |&let)
+                                                      |j $ {} (:type :expr) (:by |u0) (:at 1605671008950)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |child)
+                                                          |j $ {} (:type :expr) (:by |u0) (:at 1605671008950)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |expand-tree)
+                                                              |j $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |v)
+                                                              |r $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |coord)
+                                                              |v $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |states)
+                                                      |r $ {} (:type :expr) (:by |u0) (:at 1605671008950)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |[])
+                                                          |j $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |k)
+                                                          |r $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |child)
+                                          |v $ {} (:type :expr) (:by |u0) (:at 1605671008950)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |u0) (:at 1605671008950) (:text |pairs-map)
                   |v $ {} (:type :expr) (:by |u0) (:at 1605605077577)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |u0) (:at 1605605078524) (:text |:group)
@@ -812,6 +848,7 @@
                                           |T $ {} (:type :leaf) (:by |u0) (:at 1605605578703) (:text |expand-tree)
                                           |j $ {} (:type :leaf) (:by |u0) (:at 1605605580481) (:text |x)
                                           |r $ {} (:type :leaf) (:by |u0) (:at 1605605582954) (:text |coord)
+                                          |v $ {} (:type :leaf) (:by |u0) (:at 1605668480262) (:text |states)
                                   |r $ {} (:type :leaf) (:by |u0) (:at 1605605586240) (:text |xs)
                   |x $ {} (:type :expr) (:by |u0) (:at 1605605079234)
                     :data $ {}
@@ -819,7 +856,18 @@
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |u0) (:at 1605605082184) (:text |:type)
                           |j $ {} (:type :leaf) (:by |u0) (:at 1605605084026) (:text |tree)
-                      |j $ {} (:type :leaf) (:by |u0) (:at 1605605111125) (:text |tree)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605668611097)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605605111125) (:text |tree)
+                          |D $ {} (:type :leaf) (:by |u0) (:at 1605668613104) (:text |do)
+                          |L $ {} (:type :expr) (:by |u0) (:at 1605668613402)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605668614050) (:text |println)
+                              |j $ {} (:type :leaf) (:by |u0) (:at 1605668626256) (:text "|\"other type:")
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605668626956)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605668628393) (:text |:type)
+                                  |j $ {} (:type :leaf) (:by |u0) (:at 1605668629009) (:text |tree)
           |wrap-keywords-in-path $ {} (:type :expr) (:by |u0) (:at 1605603183115)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1605603183115) (:text |defn)
@@ -951,29 +999,7 @@
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |u0) (:at 1605606217980) (:text |:type)
                           |j $ {} (:type :leaf) (:by |u0) (:at 1605606219475) (:text |tree)
-                      |j $ {} (:type :expr) (:by |u0) (:at 1605606365573)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |u0) (:at 1605606221652) (:text |tree)
-                          |D $ {} (:type :leaf) (:by |u0) (:at 1605606367404) (:text |update)
-                          |j $ {} (:type :leaf) (:by |u0) (:at 1605606369244) (:text |:path)
-                          |r $ {} (:type :expr) (:by |u0) (:at 1605606369855)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |u0) (:at 1605606370134) (:text |fn)
-                              |j $ {} (:type :expr) (:by |u0) (:at 1605606370411)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605606371272) (:text |path)
-                              |r $ {} (:type :expr) (:by |u0) (:at 1605606372002)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605606372388) (:text |if)
-                                  |j $ {} (:type :expr) (:by |u0) (:at 1605606373249)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605606373500) (:text |nil?)
-                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605606374135) (:text |path)
-                                  |r $ {} (:type :leaf) (:by |u0) (:at 1605606375640) (:text |path)
-                                  |v $ {} (:type :expr) (:by |u0) (:at 1605606376583)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605606397766) (:text |wrap-keywords-in-path)
-                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605606399791) (:text |path)
+                      |j $ {} (:type :leaf) (:by |u0) (:at 1605671868132) (:text |tree)
                   |l $ {} (:type :expr) (:by |u0) (:at 1605609841389)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |u0) (:at 1605609841114) (:text |nil)
@@ -986,6 +1012,32 @@
                               |T $ {} (:type :leaf) (:by |u0) (:at 1605609860705) (:text |echo)
                               |j $ {} (:type :leaf) (:by |u0) (:at 1605609869244) (:text "|\"nil type from tree:")
                               |r $ {} (:type :leaf) (:by |u0) (:at 1605609870527) (:text |tree)
+                  |t $ {} (:type :expr) (:by |u0) (:at 1605671858264)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605671860318) (:text |:touch-area)
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605671865037)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |update)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |tree)
+                          |r $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |:path)
+                          |v $ {} (:type :expr) (:by |u0) (:at 1605671865037)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |fn)
+                              |j $ {} (:type :expr) (:by |u0) (:at 1605671865037)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |path)
+                              |r $ {} (:type :expr) (:by |u0) (:at 1605671865037)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |if)
+                                  |j $ {} (:type :expr) (:by |u0) (:at 1605671865037)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |nil?)
+                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |path)
+                                  |r $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |path)
+                                  |v $ {} (:type :expr) (:by |u0) (:at 1605671865037)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |wrap-keywords-in-path)
+                                      |j $ {} (:type :leaf) (:by |u0) (:at 1605671865037) (:text |path)
           |def $ {} (:type :expr) (:by |u0) (:at 1605608517690)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1605608521966) (:text |defmacro)
@@ -995,6 +1047,30 @@
                   |T $ {} (:type :leaf) (:by |u0) (:at 1605608532568) (:text |name)
                   |j $ {} (:type :leaf) (:by |u0) (:at 1605608533713) (:text |x)
               |v $ {} (:type :leaf) (:by |u0) (:at 1605608534423) (:text |x)
+          |g $ {} (:type :expr) (:by |u0) (:at 1605672941419)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1605672941419) (:text |defn)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1605672941419) (:text |g)
+              |r $ {} (:type :expr) (:by |u0) (:at 1605672941419)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1605672946191) (:text |props)
+                  |j $ {} (:type :leaf) (:by |u0) (:at 1605672948969) (:text |&)
+                  |r $ {} (:type :leaf) (:by |u0) (:at 1605672950373) (:text |xs)
+              |v $ {} (:type :expr) (:by |u0) (:at 1605672994533)
+                :data $ {}
+                  |T $ {} (:type :expr) (:by |u0) (:at 1605672950850)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |u0) (:at 1605672951278) (:text |{})
+                      |j $ {} (:type :expr) (:by |u0) (:at 1605672951471)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605672952234) (:text |:type)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605672953120) (:text |:group)
+                      |r $ {} (:type :expr) (:by |u0) (:at 1605672953768)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |u0) (:at 1605672954974) (:text |:children)
+                          |j $ {} (:type :leaf) (:by |u0) (:at 1605672956751) (:text |xs)
+                  |D $ {} (:type :leaf) (:by |u0) (:at 1605672995895) (:text |merge)
+                  |L $ {} (:type :leaf) (:by |u0) (:at 1605672996528) (:text |props)
         :proc $ {} (:type :expr) (:by |u0) (:at 1605513215399) (:data $ {})
         :configs $ {}
       |phlox.complex $ {}

--- a/compact.cirru
+++ b/compact.cirru
@@ -4,18 +4,77 @@
   :files $ {}
     |phlox.main $ {}
       :ns $ quote
-        ns phlox.main $ :require ([] phlox.complex :refer $ [] c+ c- c* rad-point)
+        ns phlox.main $ :require ([] phlox.core :refer $ [] expand-tree def get-shape-tree) ([] phlox.complex :refer $ [] c+ c- c* rad-point)
       :defs $ {}
+        |comp-todo-list $ quote
+          def comp-todo-list $ {} (:type :comp) (:s0 $ {}) (:args $ [])
+            :render $ fn (cursor state)
+              fn (& args)
+                {}
+                  :children $ merge
+                    {} $ :header
+                      merge comp-todo-task $ {} (:args $ [])
+                    ->> (range 3)
+                      map $ fn (x)
+                        [] (str |task- x)
+                          merge comp-todo-task $ {} (:args $ [] x)
+                      pair-map
+                  :render $ fn (dict)
+                    {} (:type :group)
+                      :children $ [] (get dict :header)
+                        {} (:type :group)
+                          :children $ ->> (range 3)
+                            map $ fn (x) (get dict $ str |task- x)
+            :events $ {}
         |main! $ quote
           defn main! ()
             init-canvas $ {} (:title "\"Phlox") (:width 800) (:height 800)
             render-shape
-            println "\"hello world"
-            println "\"working"
+            echo "\"app started."
+        |render-rotate $ quote
+          defn render-rotate ()
+            let
+                b0 20
+                r0 1.6
+                r1 $ / 1.48 3
+              draw-canvas $ g
+                {} (:x 200) (:y 300)
+                {} (:type :polyline) (:from $ [] 100 0)
+                  :relative-stops $ ->> (range 200)
+                    map $ fn (x)
+                      c*
+                        [] (+ b0 $ * r0 x) (, 0)
+                        rad-point $ * &PI r1 x
+                  :stroke-color $ [] 0 80 60
+                  :line-width 2
+                  :line-join :round
+                  :skip-first? true
+        |comp-todo-task $ quote
+          def comp-todo-task $ {} (:type :comp) (:args $ [])
+            :render $ fn (cursor state)
+              fn (& args)
+                {} (:children $ {})
+                  :render $ fn (dict)
+                    {} (:type :group) (:children $ [])
+            :events $ {}
+        |on-window-event $ quote
+          defn on-window-event (event) (echo event)
+        |*app-states $ quote (defatom *app-states $ {})
+        |render-shape $ quote
+          defn render-shape () (; render-cycloid)
+            &let
+              tree $ expand-tree
+                merge comp-todo-list $ {} (:args $ [])
+                []
+                deref *app-states
+              reset! *app-states tree
+              echo "\"tree:" tree
+              echo "\"shape:" $ get-shape-tree tree
+            render-rotate
         |reload! $ quote
           defn reload! () (println "\"reloaded") (render-shape)
-        |render-shape $ quote
-          defn render-shape ()
+        |render-cycloid $ quote
+          defn render-cycloid ()
             let
                 n 600
                 t1 3
@@ -36,13 +95,50 @@
                   :line-width 2
                   :line-join :round
                   :skip-first? true
-        |on-window-event $ quote
-          defn on-window-event (event) (echo event)
       :proc $ quote ()
       :configs $ {}
     |phlox.core $ {}
       :ns $ quote (ns phlox.core)
       :defs $ {}
+        |expand-tree $ quote
+          defn expand-tree (tree coord states)
+            case (:type tree)
+              :comp $ &let (renderer $ :render tree) (assert "\"render function for component" $ fn? renderer)
+                &let
+                  internal-result $ apply (renderer coord states) (:args tree)
+                  {} (:type :component) (:children $ :children internal-result)
+                    :tree $ apply (:render internal-result) ([] $ :children internal-result)
+                    :events $ :events tree
+              :group $ update tree :children
+                fn (xs)
+                  map
+                    fn (x) (expand-tree x coord)
+                    , xs
+              (:type tree)
+                , tree
+        |wrap-keywords-in-path $ quote
+          defn wrap-keywords-in-path (xs0)
+            apply
+              fn (acc xs)
+                if (empty? xs) acc $ recur
+                  append acc $ let& (x0 $ first xs)
+                    if (keyword? x0) (str "\":" $ turn-str x0) (turn-str x0)
+                  rest xs
+              [] ([]) xs0
+        |handle-tree-event $ quote (defn handle-tree-event $)
+        |*tree-state $ quote (defatom *tree-state nil)
+        |get-shape-tree $ quote
+          defn get-shape-tree (tree)
+            case (:type tree)
+              nil $ do (echo "\"nil type from tree:" tree) nil
+              :group $ update tree :children
+                fn (xs) (map get-shape-tree xs)
+              :component $ get-shape-tree (:tree tree)
+              (:type tree)
+                update tree :path $ fn (path)
+                  if (nil? path) path $ wrap-keywords-in-path path
+        |def $ quote
+          defmacro def (name x) x
       :proc $ quote ()
       :configs $ {}
     |phlox.complex $ {}
@@ -50,17 +146,17 @@
       :defs $ {}
         |c+ $ quote
           defn c+ (p1 p2)
-            &[]
+            []
               &+ (first p1) (first p2)
               &+ (last p1) (last p2)
         |c- $ quote
           defn c- (p1 p2)
-            &[]
+            []
               &- (first p1) (first p2)
               &- (last p1) (last p2)
         |c* $ quote
           defn c* (p1 p2)
-            &[]
+            []
               &-
                 &* (first p1) (first p2)
                 &* (last p1) (last p2)
@@ -69,6 +165,6 @@
                 &* (last p1) (last p2)
         |rad-point $ quote
           defn rad-point (x)
-            &[] (cos x) (sin x)
+            [] (cos x) (sin x)
       :proc $ quote ()
       :configs $ {}

--- a/compact.cirru
+++ b/compact.cirru
@@ -4,8 +4,11 @@
   :files $ {}
     |phlox.main $ {}
       :ns $ quote
-        ns phlox.main $ :require ([] phlox.core :refer $ [] expand-tree get-shape-tree g) ([] phlox.complex :refer $ [] c+ c- c* rad-point)
+        ns phlox.main $ :require ([] phlox.core :refer $ [] expand-tree get-shape-tree g >> *tree-state handle-tree-event defcomp) ([] phlox.complex :refer $ [] c+ c- c* rad-point)
       :defs $ {}
+        |*store $ quote
+          defatom *store $ {}
+            :states $ {} (:cursor $ [])
         |main! $ quote
           defn main! ()
             init-canvas $ {} (:title "\"Phlox") (:width 800) (:height 800)
@@ -30,62 +33,63 @@
                   :line-join :round
                   :skip-first? true
         |comp-counter $ quote
-          def comp-counter $ {} (:type :comp)
-            :s0 $ {} (:count 0)
-            :args $ []
-            :render $ fn (cursor state)
-              fn (c)
-                {} (:children $ {})
-                  :render $ fn (dict)
-                    g ({})
-                      {} (:type :touch-area) (:x 0) (:radius 10) (:path $ [] "\"TODO") (:events $ [] :touch-down)
-                      {} (:type :touch-area) (:x 80) (:radius 10) (:path $ [] "\"TODO") (:events $ [] :touch-down)
-                      {} (:type :text) (:x 0) (:text "\"-") (:color $ [] 0 0 100) (:align "\"center")
-                      {} (:type :text) (:x 40) (:text $ str c) (:color $ [] 0 0 100) (:align "\"center")
-                      {} (:type :text) (:x 80) (:text "\"+") (:color $ [] 0 90 100) (:align "\"center")
-            :events $ {}
+          defcomp comp-counter (states c)
+            let
+                cursor $ :cursor states
+                state $ either (:data states) ({} $ :count 0)
+              {} (:children $ {})
+                :render $ fn (dict)
+                  g ({})
+                    {} (:type :touch-area) (:x 0) (:radius 10) (:path cursor) (:events $ [] :touch-down)
+                    {} (:type :touch-area) (:x 80) (:radius 10) (:path cursor) (:events $ [] :touch-down)
+                    {} (:type :text) (:x 0) (:text "\"-") (:color $ [] 0 0 100) (:align "\"center")
+                    {} (:type :text) (:x 40) (:text $ str c) (:color $ [] 0 0 100) (:align "\"center")
+                    {} (:type :text) (:x 80) (:text "\"+") (:color $ [] 0 90 100) (:align "\"center")
+                :events $ {}
         |on-window-event $ quote
-          defn on-window-event (event) (echo event)
-        |*app-states $ quote (defatom *app-states $ {})
+          defn on-window-event (event) (handle-tree-event event)
         |comp-data-list $ quote
-          def comp-data-list $ {} (:type :comp)
-            :s0 $ {} (:size 0)
-            :args $ []
-            :render $ fn (cursor state)
-              fn ()
-                {}
-                  :children $ ->> (range 3)
-                    map $ fn (x)
-                      [] (str |task- x)
-                        g
-                          {} (:x 0) (:y $ * x 30)
-                          merge comp-counter $ {} (:args $ [] x)
-                    pairs-map
-                  :render $ fn (dict)
-                    {} (:type :group) (:x 0) (:y 0)
-                      :children $ []
-                        {} (:type :group)
-                          :children $ []
-                            {} (:type :text) (:x 20) (:y 20)
-                              :text $ str "\"Size: " (:size state)
-                              :color $ [] 0 0 100
-                              :align "\"center"
-                            g
-                              {} (:x 40) (:y 60)
-                              , &
-                              ->> (range 3)
-                                map $ fn (x) (get dict $ str |task- x)
-            :events $ {}
+          defcomp comp-data-list (store)
+            let
+                states $ :states store
+                cursor $ :cursor states
+                state $ either (:data states) ({} $ :size 0)
+              {}
+                :children $ ->> (range 3)
+                  map $ fn (x)
+                    [] (str |task- x)
+                      g
+                        {} (:x 0) (:y $ * x 30)
+                        merge comp-counter $ {}
+                          :args $ [] (>> states x) x
+                  pairs-map
+                :render $ fn (dict)
+                  {} (:type :group) (:x 0) (:y 0)
+                    :children $ []
+                      {} (:type :group)
+                        :children $ []
+                          {} (:type :text) (:x 20) (:y 20)
+                            :text $ str "\"Size: " (:size state)
+                            :color $ [] 0 0 100
+                            :align "\"center"
+                          g
+                            {} (:x 40) (:y 60)
+                            , &
+                            ->> (range 3)
+                              map $ fn (x) (get dict $ str |task- x)
+                :events $ {}
         |render-shape $ quote
           defn render-shape () (; render-cycloid) (; render-rotate)
             &let
               tree $ expand-tree
-                merge comp-data-list $ {} (:args $ [])
-                []
-                deref *app-states
-              reset! *app-states tree
+                merge comp-data-list $ {}
+                  :args $ [] (deref *store)
+              reset! *tree-state tree
               ; echo "\"tree:"
               ; echo tree
+              ; echo "\"Generated" $ macroexpand
+                quote $ defcomp comp-name (a b)
+                  {} (:children nil) (:tree nil) (:events $ {})
               &let (info $ get-shape-tree tree) (echo "\"shape:") (echo info) (draw-canvas info)
         |reload! $ quote
           defn reload! () (println "\"reloaded") (render-shape)
@@ -116,10 +120,32 @@
     |phlox.core $ {}
       :ns $ quote (ns phlox.core)
       :defs $ {}
+        |>> $ quote
+          defn >> (states k)
+            let
+                parent-cursor $ either (:cursor states) ([])
+                branch $ get states k
+              assoc (either branch $ {}) (, :cursor) (append parent-cursor k)
         |wrap-kwd-in-list $ quote
-          defn wrap-kwd-in-list (xs0) (map wrap-keywords-in-path xs0)
+          defn wrap-kwd-in-list (xs0) (map wrap-kwd-in-path xs0)
         |*tree-state $ quote (defatom *tree-state nil)
-        |handle-tree-event $ quote (defn handle-tree-event $)
+        |wrap-kwd-in-event $ quote
+          defn wrap-kwd-in-event (x)
+            case (type-of x)
+              :map $ ->> x
+                map-kv $ fn (k v)
+                  []
+                    if (string? k) (turn-keyword k) (, k)
+                    wrap-kwd-in-event v
+                pairs-map
+              :vec $ map wrap-kwd-in-event x
+              (type-of x)
+                , x
+        |handle-tree-event $ quote
+          defn handle-tree-event (event)
+            let
+                e $ wrap-kwd-in-event event
+              if (some? $ :path e) (echo e)
         |get-shape-tree $ quote
           defn get-shape-tree (tree)
             case (:type tree)
@@ -129,31 +155,24 @@
               :component $ get-shape-tree (:tree tree)
               :touch-area $ update tree :path
                 fn (path)
-                  if (nil? path) path $ wrap-keywords-in-path path
+                  if (nil? path) path $ wrap-kwd-in-path path
               (:type tree)
                 , tree
-        |wrap-keywords-in-path $ quote
-          defn wrap-keywords-in-path (x)
-            case (type-of x) (:list $ wrap-kwd-in-list x)
-              :map (wrap-kwd-in-map x) 
-              :keyword $ str "\":" (turn-str x0)
-              (type-of x)
-                , x
         |wrap-kwd-in-map $ quote
           defn wrap-kwd-in-map (xs)
             ->> xs
               map-kv $ fn (k v)
-                [] (wrap-keywords-in-path k) (wrap-keywords-in-path v)
+                [] (wrap-kwd-in-path k) (wrap-kwd-in-path v)
               pairs-map
         |expand-tree $ quote
-          defn expand-tree (tree coord states)
+          defn expand-tree (tree)
             case (:type tree)
               :comp $ &let (renderer $ :render tree) (assert "\"render function for component" $ fn? renderer)
                 let
-                    internal-result $ apply (renderer coord states) (:args tree)
+                    internal-result $ apply renderer (:args tree)
                     children $ ->> (:children internal-result)
                       map-kv $ fn (k v)
-                        &let (child $ expand-tree v coord states) ([] k child)
+                        &let (child $ expand-tree v) ([] k child)
                       pairs-map
                   {} (:type :component) (:children children)
                     :tree $ apply (:render internal-result) ([] children)
@@ -161,13 +180,30 @@
               :group $ update tree :children
                 fn (xs)
                   map
-                    fn (x) (expand-tree x coord states)
+                    fn (x) (expand-tree x)
                     , xs
               (:type tree)
                 do (println "\"other type:" $ :type tree) (, tree)
         |g $ quote
           defn g (props & xs)
             merge props $ {} (:type :group) (:children xs)
+        |wrap-kwd-in-path $ quote
+          defn wrap-kwd-in-path (x)
+            case (type-of x) (:list $ wrap-kwd-in-list x)
+              :map (wrap-kwd-in-map x) 
+              :keyword $ str "\":" (turn-str x0)
+              (type-of x)
+                , x
+        |defcomp $ quote
+          defmacro defcomp (comp-name args & body)
+            quote-replace $ {} (:type :comp)
+              :name $ ~ (turn-keyword comp-name)
+              :args $ []
+              :render $ fn (~ args)
+                &let
+                  ret $ do (~@ body)
+                  assert "\"component returns a map" $ map? ret
+                  , ret
       :proc $ quote ()
       :configs $ {}
     |phlox.complex $ {}


### PR DESCRIPTION
`defcomp` is added based on previous work in Quamolit/phlox. Keywords are handled in a simple way in events. Component data structure should be stable now.
